### PR TITLE
[issues-2] feat(agents): mirror Claude Code session display title above hero sprites

### DIFF
--- a/client/src/editor/panels/EditorTopBar.tsx
+++ b/client/src/editor/panels/EditorTopBar.tsx
@@ -1,6 +1,7 @@
 import { editorBridge } from '../EditorBridge';
 import { editorStore, useEditorStore } from '../state/editor-store';
 import type { SlotInfo } from '../types/map';
+import { truncateLabel } from '../../game/entities/truncateLabel';
 
 export function EditorTopBar() {
   const dirty = useEditorStore((s) => s.dirty);
@@ -57,7 +58,7 @@ export function EditorTopBar() {
   const getSlotLabel = (info: SlotInfo): string => {
     const star = info.isActive ? ' \u2605' : '';
     if (info.isEmpty) return `${info.slot}${star}`;
-    const name = info.name.length > 10 ? info.name.slice(0, 10) + '...' : info.name;
+    const name = truncateLabel(info.name, 10);
     return `${info.slot} \u2014 ${name}${star}`;
   };
 

--- a/client/src/game/entities/HeroSprite.ts
+++ b/client/src/game/entities/HeroSprite.ts
@@ -3,6 +3,7 @@ import { HERO_COLOR_SPRITE_BASE, HERO_LABEL_COLOR, SOURCE_BADGE_COLOR, modelBadg
 import { getActiveTheme } from '../themes/registry';
 import { findRoadPath, type Point } from '../data/road-network';
 import { addCrispText } from '../text';
+import { truncateLabel } from './truncateLabel';
 
 const MOVE_SPEED = 150;
 /** Ground distance covered by one full run-cycle. Keeps legs synced to travel. */
@@ -15,6 +16,13 @@ const RUN_PIXELS_PER_CYCLE = 60;
  * (sprite 96 px → name -50, activity +46, detail +60, task +74).
  */
 const TASK_MAX_CHARS = 28;
+/**
+ * Hero head labels mirror the user's `cc_session_step` output —
+ * `[#1234, 12/13] some long description`. Cap roughly matches Claude Code's
+ * own `agents` view column so the label stays readable above the sprite
+ * without bleeding into adjacent heroes.
+ */
+const NAME_MAX_CHARS = 40;
 
 const ACTIVITY_COLOR: Record<AgentActivity, string> = {
   idle:      '#888888',
@@ -182,7 +190,7 @@ export class HeroSprite {
 
     const nameColor = HERO_LABEL_COLOR[heroColor] ?? '#DDDDDD';
     this.nameBaseColor = nameColor;
-    this.nameText = addCrispText(scene, x, y + this.nameOffsetY, name, {
+    this.nameText = addCrispText(scene, x, y + this.nameOffsetY, truncateLabel(name, NAME_MAX_CHARS), {
       fontSize: '14px',
       color: nameColor,
       fontFamily: 'monospace',
@@ -522,17 +530,26 @@ export class HeroSprite {
     this.modelText.setPosition(leftEdge + widthA + gap, y);
   }
 
+  /**
+   * Update the name label above the hero. Truncates with an ellipsis when the
+   * label exceeds NAME_MAX_CHARS so the rest of the head stack (subagent
+   * marker, activity, detail, task) stays inside the hero's visual footprint.
+   * No-op when `name` matches what's already rendered (avoids touching the
+   * Phaser text object on every WebSocket tick).
+   */
+  updateName(name: string): void {
+    const truncated = truncateLabel(name, NAME_MAX_CHARS);
+    if (this.nameText.text === truncated) return;
+    this.nameText.setText(truncated);
+  }
+
   /** Update the truncated task line shown below the detail. */
   updateTask(task?: string): void {
     if (task === undefined || task.length === 0) {
       this.taskText.setText('');
       return;
     }
-    const single = task.replace(/\s+/g, ' ').trim();
-    const text = single.length > TASK_MAX_CHARS
-      ? single.slice(0, TASK_MAX_CHARS - 1) + '\u2026'
-      : single;
-    this.taskText.setText(text);
+    this.taskText.setText(truncateLabel(task, TASK_MAX_CHARS));
   }
 
   /** Update the detail line shown below the activity label. */
@@ -543,7 +560,7 @@ export class HeroSprite {
       const parts = file.split('/');
       detail = parts[parts.length - 1] ?? file;
     } else if (command) {
-      detail = command.length > 25 ? command.slice(0, 24) + '\u2026' : command;
+      detail = truncateLabel(command, 25);
     }
     this.detailText.setText(detail);
   }

--- a/client/src/game/entities/truncateLabel.test.ts
+++ b/client/src/game/entities/truncateLabel.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from 'bun:test';
+
+import { truncateLabel } from './truncateLabel';
+
+describe('truncateLabel', () => {
+  test('returns the input untouched when shorter than the limit', () => {
+    expect(truncateLabel('short', 40)).toBe('short');
+  });
+
+  test('returns the input untouched when exactly the limit', () => {
+    const exact = 'x'.repeat(40);
+    expect(truncateLabel(exact, 40)).toBe(exact);
+  });
+
+  test('clips with an ellipsis when longer than the limit', () => {
+    const long = 'x'.repeat(50);
+    const out = truncateLabel(long, 10);
+    expect(out).toBe('xxxxxxxxx…');
+    expect([...out].length).toBe(10);
+  });
+
+  test('collapses whitespace runs to single spaces', () => {
+    expect(truncateLabel('feat:\n  fix\t\tcrash', 40)).toBe('feat: fix crash');
+  });
+
+  test('trims leading and trailing whitespace before measuring length', () => {
+    // Without trim, the input has 8 chars and would not be truncated at 7;
+    // after trim it's 5 chars and stays intact.
+    expect(truncateLabel('   foo   ', 7)).toBe('foo');
+  });
+
+  test('does not slice an emoji in half (code-point safe)', () => {
+    // Each rocket is one user-perceived character but two UTF-16 code units.
+    // A naive `slice` would cut the second rocket mid-surrogate-pair and the
+    // canvas would render the U+FFFD replacement glyph.
+    const input = '🚀🚀🚀🚀🚀';
+    const out = truncateLabel(input, 3);
+    expect(out).toBe('🚀🚀…');
+    // The ellipsis is one code point — total three "characters".
+    expect([...out].length).toBe(3);
+  });
+
+  test('handles empty input', () => {
+    expect(truncateLabel('', 40)).toBe('');
+    expect(truncateLabel('   ', 40)).toBe('');
+  });
+
+  test('handles a max of 1 (degenerate but legal)', () => {
+    // After trim the single remaining char fits; ellipsis only kicks in past the cap.
+    expect(truncateLabel('a', 1)).toBe('a');
+    expect(truncateLabel('ab', 1)).toBe('…');
+  });
+});

--- a/client/src/game/entities/truncateLabel.ts
+++ b/client/src/game/entities/truncateLabel.ts
@@ -1,0 +1,15 @@
+/**
+ * Collapse whitespace and clip to `max` chars — every head-stack label sits on
+ * a single line, so wrapped multi-line strings would push neighbouring badges
+ * out of frame. The ellipsis preserves intent ("there was more") without
+ * leaking formatting noise (newlines, tabs) into the canvas. Spread iterates
+ * code points (not UTF-16 code units), so emoji and other supplementary-plane
+ * characters don't get sliced mid-surrogate-pair and render as replacement
+ * glyphs above the hero.
+ */
+export function truncateLabel(text: string, max: number): string {
+  const single = text.replace(/\s+/g, ' ').trim();
+  const chars = [...single];
+  if (chars.length <= max) return single;
+  return chars.slice(0, max - 1).join('') + '…';
+}

--- a/client/src/game/scenes/VillageScene.ts
+++ b/client/src/game/scenes/VillageScene.ts
@@ -697,6 +697,7 @@ export class VillageScene extends Phaser.Scene {
         buildingsToReposition.add(buildingDef.id);
       } else {
         // Always update detail text (file/command changes even without activity change)
+        existing.updateName(agent.name);
         existing.updateDetail(agent.currentFile, agent.currentCommand);
         existing.updateTask(agent.currentTask);
         existing.setStatus(agent.status);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -53,6 +53,7 @@ const stateManager = new AgentStateManager({
   subagentCompletedThresholdMs: SUBAGENT_COMPLETED_THRESHOLD_MS,
   subagentBusyCompletedThresholdMs: SUBAGENT_BUSY_COMPLETED_THRESHOLD_MS,
   livenessOracle: sessionRegistry,
+  displayNameOracle: sessionRegistry,
 });
 const wsServer = new WebSocketServer();
 const mapStorage = new MapStorage();

--- a/server/src/session-registry.test.ts
+++ b/server/src/session-registry.test.ts
@@ -5,13 +5,38 @@ import { join } from 'node:path';
 
 import { SessionRegistry } from './session-registry';
 
-async function makeClaudeDir(withSessions: Array<{ pid: number; sessionId: string }>): Promise<string> {
+interface SessionStub {
+  pid: number;
+  sessionId: string;
+  /** When set, the stub also writes `<root>/jobs/<jobId>/state.json` so the display-name oracle has something to read. */
+  jobId?: string;
+  /** When set, the corresponding `jobs/<jobId>/state.json` carries this `name`. */
+  displayName?: string;
+}
+
+async function makeClaudeDir(withSessions: SessionStub[]): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'agent-quest-test-'));
   const sessionsDir = join(root, 'sessions');
   await mkdir(sessionsDir, { recursive: true });
-  for (const { pid, sessionId } of withSessions) {
+  for (const stub of withSessions) {
+    const { pid, sessionId, jobId, displayName } = stub;
     const file = join(sessionsDir, `${pid}.json`);
-    await writeFile(file, JSON.stringify({ pid, sessionId, cwd: '/tmp', startedAt: Date.now(), kind: 'interactive', entrypoint: 'cli' }));
+    const payload: Record<string, unknown> = {
+      pid,
+      sessionId,
+      cwd: '/tmp',
+      startedAt: Date.now(),
+      kind: 'interactive',
+      entrypoint: 'cli',
+    };
+    if (jobId !== undefined) payload['jobId'] = jobId;
+    await writeFile(file, JSON.stringify(payload));
+
+    if (jobId !== undefined && displayName !== undefined) {
+      const jobDir = join(root, 'jobs', jobId);
+      await mkdir(jobDir, { recursive: true });
+      await writeFile(join(jobDir, 'state.json'), JSON.stringify({ name: displayName }));
+    }
   }
   return root;
 }
@@ -116,6 +141,89 @@ describe('SessionRegistry', () => {
     });
     await reg.scan();
     expect(reg.hasAnyLive()).toBe(false);
+  });
+
+  test('exposes display name read from jobs/<jobId>/state.json', async () => {
+    const dir = await makeClaudeDir([
+      { pid: 11, sessionId: 'with-job', jobId: 'job-abc', displayName: '[#42, 7/13] feat: foo' },
+      { pid: 12, sessionId: 'no-job' },
+    ]);
+    tempDirs.push(dir);
+
+    const reg = new SessionRegistry({ configDirs: [dir], pidAlive: () => true });
+    await reg.scan();
+
+    expect(reg.getDisplayName('with-job')).toBe('[#42, 7/13] feat: foo');
+    // No jobId → no display name (caller falls back to slug/cwd).
+    expect(reg.getDisplayName('no-job')).toBeUndefined();
+    // Unknown sessionId → undefined.
+    expect(reg.getDisplayName('never-seen')).toBeUndefined();
+  });
+
+  test('forgets display name when state.json is removed between scans', async () => {
+    const dir = await makeClaudeDir([
+      { pid: 21, sessionId: 'sid-21', jobId: 'job-21', displayName: '[#7, 2/13] initial' },
+    ]);
+    tempDirs.push(dir);
+
+    const reg = new SessionRegistry({ configDirs: [dir], pidAlive: () => true });
+    await reg.scan();
+    expect(reg.getDisplayName('sid-21')).toBe('[#7, 2/13] initial');
+
+    await rm(join(dir, 'jobs', 'job-21', 'state.json'));
+    await reg.scan();
+    expect(reg.getDisplayName('sid-21')).toBeUndefined();
+  });
+
+  test('picks up display name changes between scans (live retitle)', async () => {
+    const dir = await makeClaudeDir([
+      { pid: 31, sessionId: 'sid-31', jobId: 'job-31', displayName: '[#9, 2/13] foo' },
+    ]);
+    tempDirs.push(dir);
+
+    const reg = new SessionRegistry({ configDirs: [dir], pidAlive: () => true });
+    await reg.scan();
+    expect(reg.getDisplayName('sid-31')).toBe('[#9, 2/13] foo');
+
+    await writeFile(
+      join(dir, 'jobs', 'job-31', 'state.json'),
+      JSON.stringify({ name: '[#9, 12/13] foo' }),
+    );
+    await reg.scan();
+    expect(reg.getDisplayName('sid-31')).toBe('[#9, 12/13] foo');
+  });
+
+  test('tolerates corrupt state.json (returns undefined)', async () => {
+    const dir = await makeClaudeDir([
+      { pid: 41, sessionId: 'sid-41', jobId: 'job-41' },
+    ]);
+    tempDirs.push(dir);
+    // Write a malformed state.json manually.
+    const jobDir = join(dir, 'jobs', 'job-41');
+    await mkdir(jobDir, { recursive: true });
+    await writeFile(join(jobDir, 'state.json'), '{not json');
+
+    const reg = new SessionRegistry({ configDirs: [dir], pidAlive: () => true });
+    await reg.scan();
+
+    // Liveness still works; only displayName degrades gracefully.
+    expect(reg.isLive('sid-41')).toBe(true);
+    expect(reg.getDisplayName('sid-41')).toBeUndefined();
+  });
+
+  test('drops display name for sessions whose pid is dead', async () => {
+    const dir = await makeClaudeDir([
+      { pid: 51, sessionId: 'sid-51', jobId: 'job-51', displayName: '[#1, 5/13] x' },
+    ]);
+    tempDirs.push(dir);
+
+    const reg = new SessionRegistry({ configDirs: [dir], pidAlive: () => false });
+    await reg.scan();
+
+    // Dead pid: registry must not surface stale display names — otherwise the
+    // dashboard would keep ghost sessions visible under their last-known title.
+    expect(reg.isLive('sid-51')).toBe(false);
+    expect(reg.getDisplayName('sid-51')).toBeUndefined();
   });
 
   test('setConfigDirs refreshes the watched roots', async () => {

--- a/server/src/session-registry.ts
+++ b/server/src/session-registry.ts
@@ -1,18 +1,38 @@
 import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import type { SessionLivenessOracle } from './state/agent-state-manager';
+import type { SessionDisplayNameOracle, SessionLivenessOracle } from './state/agent-state-manager';
 
-/** Reads `sessionId` out of a `<pid>.json` file. Tolerates noise and missing fields. */
-async function readSessionIdFrom(filePath: string): Promise<string | null> {
+/** Reads `sessionId` and `jobId` out of a `<pid>.json` file. Tolerates noise and missing fields. */
+async function readSessionMetaFrom(filePath: string): Promise<{ sessionId: string; jobId: string | null } | null> {
   try {
     const text = await Bun.file(filePath).text();
-    const data = JSON.parse(text) as { sessionId?: unknown };
+    const data = JSON.parse(text) as { sessionId?: unknown; jobId?: unknown };
     if (typeof data.sessionId === 'string' && data.sessionId.length > 0) {
-      return data.sessionId;
+      const jobId = typeof data.jobId === 'string' && data.jobId.length > 0 ? data.jobId : null;
+      return { sessionId: data.sessionId, jobId };
     }
   } catch {
     // unreadable / not JSON / partially-written — just ignore this file
+  }
+  return null;
+}
+
+/**
+ * Reads the human-friendly display name out of `<configDir>/jobs/<jobId>/state.json`.
+ * This is the same `name` field that Claude Code's `claude agents` view renders in
+ * the left column — see `~/.claude/rules/session-display-name.md`. Returns null
+ * when the file is missing, unparseable, or omits the field.
+ */
+async function readDisplayNameFrom(filePath: string): Promise<string | null> {
+  try {
+    const text = await Bun.file(filePath).text();
+    const data = JSON.parse(text) as { name?: unknown };
+    if (typeof data.name === 'string' && data.name.length > 0) {
+      return data.name;
+    }
+  } catch {
+    // missing / unreadable / not JSON — fall back to slug/cwd at the caller.
   }
   return null;
 }
@@ -44,10 +64,11 @@ export interface SessionRegistryOptions {
  * agents whose JSONLs were touched by Claude Code resume/hook machinery but
  * whose real process has long since exited.
  */
-export class SessionRegistry implements SessionLivenessOracle {
+export class SessionRegistry implements SessionLivenessOracle, SessionDisplayNameOracle {
   private configDirs: string[];
   private pidAlive: PidLivenessCheck;
   private liveSessionIds = new Set<string>();
+  private displayNames = new Map<string, string>();
   private scanned = false;
   private pollInterval: ReturnType<typeof setInterval> | null = null;
 
@@ -67,6 +88,15 @@ export class SessionRegistry implements SessionLivenessOracle {
 
   isLive(sessionId: string): boolean {
     return this.liveSessionIds.has(sessionId);
+  }
+
+  /**
+   * Returns the user-set display name for a live Claude session, or undefined
+   * when the session has no jobId, no state.json, or the file omits the field.
+   * Callers fall back to slug/cwd in that case.
+   */
+  getDisplayName(sessionId: string): string | undefined {
+    return this.displayNames.get(sessionId);
   }
 
   /** Current live session IDs (copy, for debugging/snapshots). */
@@ -92,6 +122,7 @@ export class SessionRegistry implements SessionLivenessOracle {
 
   async scan(): Promise<void> {
     const next = new Set<string>();
+    const nextNames = new Map<string, string>();
     for (const configDir of this.configDirs) {
       const sessionsDir = join(configDir, 'sessions');
       let entries: string[];
@@ -106,11 +137,18 @@ export class SessionRegistry implements SessionLivenessOracle {
         const pid = Number.parseInt(pidMatch[1]!, 10);
         if (!Number.isFinite(pid) || pid <= 0) continue;
         if (!this.pidAlive(pid)) continue;
-        const sessionId = await readSessionIdFrom(join(sessionsDir, entry));
-        if (sessionId !== null) next.add(sessionId);
+        const meta = await readSessionMetaFrom(join(sessionsDir, entry));
+        if (meta === null) continue;
+        next.add(meta.sessionId);
+        if (meta.jobId !== null) {
+          const statePath = join(configDir, 'jobs', meta.jobId, 'state.json');
+          const displayName = await readDisplayNameFrom(statePath);
+          if (displayName !== null) nextNames.set(meta.sessionId, displayName);
+        }
       }
     }
     this.liveSessionIds = next;
+    this.displayNames = nextNames;
     this.scanned = true;
   }
 }

--- a/server/src/state/agent-state-manager.test.ts
+++ b/server/src/state/agent-state-manager.test.ts
@@ -740,4 +740,86 @@ describe('AgentStateManager', () => {
     expect(res!.agent.source).toBe('codex');
     expect(res!.agent.status).toBe('active');  // NOT completed despite oracle saying "not live"
   });
+
+  test('display-name oracle overrides slug on agent creation', () => {
+    const displayNames = new Map<string, string>([['sess-1', '[#42, 7/13] feat: foo']]);
+    const m = new AgentStateManager({
+      displayNameOracle: { getDisplayName: (sid) => displayNames.get(sid) },
+    });
+
+    const result = m.processEvent(makeEvent());
+
+    expect(result!.agent.name).toBe('[#42, 7/13] feat: foo');
+  });
+
+  test('display-name oracle falls back to slug when no name is set', () => {
+    const m = new AgentStateManager({
+      displayNameOracle: { getDisplayName: () => undefined },
+    });
+
+    const result = m.processEvent(makeEvent());
+
+    expect(result!.agent.name).toBe('bubbly-waddling-cat');
+  });
+
+  test('display-name oracle updates the agent label on subsequent events', () => {
+    const displayNames = new Map<string, string>();
+    const m = new AgentStateManager({
+      displayNameOracle: { getDisplayName: (sid) => displayNames.get(sid) },
+    });
+
+    const initial = m.processEvent(makeEvent());
+    expect(initial!.agent.name).toBe('bubbly-waddling-cat');
+
+    // User retitles the session mid-run (cc_session_step 12) — the next
+    // processEvent must surface the new label without waiting for refreshAll.
+    displayNames.set('sess-1', '[#42, 12/13] feat: foo');
+    const next = m.processEvent(makeEvent({ timestamp: Date.now() + 1 }));
+
+    expect(next!.agent.name).toBe('[#42, 12/13] feat: foo');
+  });
+
+  test('refreshAll picks up display-name changes and reports them as changed', () => {
+    const displayNames = new Map<string, string>();
+    const m = new AgentStateManager({
+      displayNameOracle: { getDisplayName: (sid) => displayNames.get(sid) },
+    });
+    m.processEvent(makeEvent());
+    expect(m.getAgent('sess-1')!.name).toBe('bubbly-waddling-cat');
+
+    // No JSONL event arrived, but the registry's next scan tick discovered a
+    // new state.json. refreshAll must rebroadcast on the strength of the name
+    // change alone — otherwise the dashboard freezes on the stale slug.
+    displayNames.set('sess-1', '[#42, DONE] feat: foo');
+    const changed = m.refreshAll();
+
+    expect(changed).toContain('sess-1');
+    expect(m.getAgent('sess-1')!.name).toBe('[#42, DONE] feat: foo');
+  });
+
+  test('display-name oracle does NOT relabel subagents (they have no jobId)', () => {
+    const m = new AgentStateManager({
+      displayNameOracle: {
+        // Bug-bait: an oracle that returns a value for a subagent id would
+        // wipe the filename-derived label, so the manager must skip the lookup.
+        getDisplayName: () => '[#42, 7/13] feat: foo',
+      },
+    });
+
+    const result = m.processEvent(makeEvent({ sessionId: 'agent-helper-1234567890abcdef' }), '', 'claude', 'helper');
+
+    expect(result!.agent.name).toBe('helper');
+  });
+
+  test('setDisplayNameOracle wires the oracle after construction', () => {
+    const m = new AgentStateManager();
+    m.processEvent(makeEvent());
+    expect(m.getAgent('sess-1')!.name).toBe('bubbly-waddling-cat');
+
+    m.setDisplayNameOracle({ getDisplayName: () => '[#1, 5/13] late wiring' });
+    const changed = m.refreshAll();
+
+    expect(changed).toContain('sess-1');
+    expect(m.getAgent('sess-1')!.name).toBe('[#1, 5/13] late wiring');
+  });
 });

--- a/server/src/state/agent-state-manager.ts
+++ b/server/src/state/agent-state-manager.ts
@@ -49,6 +49,17 @@ export interface SessionLivenessOracle {
   isLive(sessionId: string): boolean;
 }
 
+/**
+ * Display-name oracle: returns the user-set session title (the same string the
+ * `claude agents` view shows in its left column). Sourced from
+ * `<configDir>/jobs/<jobId>/state.json` per `~/.claude/rules/session-display-name.md`.
+ * Returns undefined when the session has no jobId, no state file, or no name —
+ * callers fall back to slug/cwd-basename derivation.
+ */
+export interface SessionDisplayNameOracle {
+  getDisplayName(sessionId: string): string | undefined;
+}
+
 export interface AgentStateManagerOptions {
   /** Age above which an agent transitions from active → idle (ms). Default 5 min. */
   idleThresholdMs?: number;
@@ -72,6 +83,8 @@ export interface AgentStateManagerOptions {
   subagentBusyCompletedThresholdMs?: number;
   /** Optional oracle for cross-referencing sessions against live Claude pids. */
   livenessOracle?: SessionLivenessOracle;
+  /** Optional oracle for surfacing the user-set session display name as the agent label. */
+  displayNameOracle?: SessionDisplayNameOracle;
 }
 
 function isSubagentSessionId(sessionId: string): boolean {
@@ -89,6 +102,7 @@ export class AgentStateManager {
   private subagentCompletedThresholdMs: number;
   private subagentBusyCompletedThresholdMs: number;
   private livenessOracle: SessionLivenessOracle | undefined;
+  private displayNameOracle: SessionDisplayNameOracle | undefined;
 
   constructor(opts: AgentStateManagerOptions = {}) {
     this.idleThresholdMs = opts.idleThresholdMs ?? 5 * 60_000;
@@ -98,10 +112,15 @@ export class AgentStateManager {
     this.subagentCompletedThresholdMs = opts.subagentCompletedThresholdMs ?? 5 * 60_000;
     this.subagentBusyCompletedThresholdMs = opts.subagentBusyCompletedThresholdMs ?? 15 * 60_000;
     this.livenessOracle = opts.livenessOracle;
+    this.displayNameOracle = opts.displayNameOracle;
   }
 
   setLivenessOracle(oracle: SessionLivenessOracle | undefined): void {
     this.livenessOracle = oracle;
+  }
+
+  setDisplayNameOracle(oracle: SessionDisplayNameOracle | undefined): void {
+    this.displayNameOracle = oracle;
   }
 
   processEvent(
@@ -129,6 +148,7 @@ export class AgentStateManager {
       this.applyTurnAndError(agent, event);
       // Liveness wins over turn-end: a dead pid can't be mid-turn.
       this.applyLivenessOverride(agent);
+      this.applyDisplayName(agent);
       return { agent, isNew: true };
     }
 
@@ -141,6 +161,7 @@ export class AgentStateManager {
       this.applyTurnAndError(existing, event);
       this.applyLivenessOverride(existing);
     }
+    this.applyDisplayName(existing);
     return { agent: existing, isNew: false };
   }
 
@@ -150,12 +171,32 @@ export class AgentStateManager {
     for (const agent of this.agents.values()) {
       const before = agent.status;
       const beforeActivity = agent.currentActivity;
+      const beforeName = agent.name;
       this.applyDerivedStatus(agent);
-      if (agent.status !== before || agent.currentActivity !== beforeActivity) {
+      this.applyDisplayName(agent);
+      if (
+        agent.status !== before ||
+        agent.currentActivity !== beforeActivity ||
+        agent.name !== beforeName
+      ) {
         changed.push(agent.id);
       }
     }
     return changed;
+  }
+
+  /**
+   * Overwrite `agent.name` with the user-set display name when the oracle
+   * exposes one. Subagents are skipped — they have no jobId of their own and
+   * are intentionally labelled from the filename descriptor.
+   */
+  private applyDisplayName(agent: AgentState): void {
+    if (this.displayNameOracle === undefined) return;
+    if (isSubagentSessionId(agent.id)) return;
+    const name = this.displayNameOracle.getDisplayName(agent.id);
+    if (name !== undefined && name.length > 0) {
+      agent.name = name;
+    }
   }
 
   /**


### PR DESCRIPTION
## Summary

마을 hero sprite 머리 위 이름을 Claude Code `claude agents` 뷰의 session display title (예: `[#3170, 7/13] feat: foo`) 과 동일하게 표시한다.

### Server
- `SessionRegistry`가 `<configDir>/sessions/<pid>.json` 에서 `jobId` 를 추출하고 `<configDir>/jobs/<jobId>/state.json` 의 `name` 필드를 `sessionId → displayName` 매핑으로 캐시한다.
- 새 `SessionDisplayNameOracle` 인터페이스로 `AgentStateManager` 에 주입. `processEvent` / `refreshAll` 양쪽에서 oracle 결과를 `agent.name` 에 적용 (기존 slug/cwd fallback 보존, Codex/subagent 는 skip).
- 기존 10초 polling (refresh tick) 으로 실시간 retitle 반영.

### Client
- `HeroSprite.updateName(name)` 추가 — idempotent guard 로 매 WebSocket tick 마다 불필요한 `setText` DOM 터치 회피.
- `truncateLabel(text, max)` helper 분리 (`client/src/game/entities/truncateLabel.ts`) — code-point safe (이모지 surrogate pair 보존), whitespace collapse + ellipsis 일관 적용.
- 생성자 / `updateName` / `updateTask` / `updateDetail` / `EditorTopBar` 슬롯 라벨 모두 같은 helper 사용 (동일 패턴 5곳 통일).
- `VillageScene` 의 existing hero update loop 가 `existing.updateName(agent.name)` 호출.

## Test plan

- [x] `bun test` (server) — 156 pass (oracle scan + apply + refresh, real fs IO 포함)
- [x] `bun test` (client) — 90 pass (truncateLabel 8 신규: emoji surrogate-pair, whitespace, edge cases)
- [x] `bunx tsc -b --noEmit` (client) — clean
- [x] design-director Verify — SHIP
- [x] ui-ux audit — SHIP (MEDIUM 권고 2건 in-PR fix 완료)
- [ ] dev server smoke (사용자 server 와 port 4444 충돌로 skip — 단위 테스트가 real fs 동작 검증)

Closes #2

---
<details>
<summary>🤖 Claude Code session</summary>

- Session ID: `0f331a5d-329e-4260-a4c1-b3ec8861fc72`
- Resume: `claudeauto --resume 0f331a5d-329e-4260-a4c1-b3ec8861fc72`
- Transcript: `/Users/ms/.claude/projects/-Users-ms/0f331a5d-329e-4260-a4c1-b3ec8861fc72.jsonl`
</details>