### PR TITLE
[issues-24] sub-agent 시각 구분 강화 — glow ring, gear badge, 점선 연결선

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -6,7 +6,7 @@
     <title>Agent Quest</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Fira+Code:wght@400;500&display=swap" rel="stylesheet" />
+    <link href="https://fonts.googleapis.com/css2?family=Cinzel:wght@400;700&family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet" />
     <style>
       * { margin: 0; padding: 0; box-sizing: border-box; }
       html, body, #root { width: 100%; height: 100%; overflow: hidden; background: #1a1a2e; }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,9 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useMemo, useState, useCallback } from 'react';
 import { PhaserGame } from './game/PhaserGame';
 import { useAgentState } from './hooks/useAgentState';
 import { useSelectedAgent } from './hooks/useSelectedAgent';
+import { useTopBarPrefs } from './hooks/useTopBarPrefs';
+import { computeShowSourceBadge, filterAgentsForPresentation } from './presentation/agentPresentation';
 import { eventBridge } from './game/EventBridge';
 import { TopBar } from './components/TopBar';
 import { PartyBar } from './components/PartyBar';
@@ -15,6 +17,15 @@ import './App.css';
 export default function App() {
   const { agents, activityLog, connected, configDirs } = useAgentState();
   const { selectedAgentId, selectAgent } = useSelectedAgent();
+  const [topBarPrefs, updateTopBarPrefs] = useTopBarPrefs();
+
+  // Presentation projection: agents shown in the Party Bar and the Phaser
+  // village scene. TopBar stats, DetailPanel lookup, ActivityFeed, and
+  // BuildingInfoPanel continue to use the unfiltered `agents` snapshot.
+  const presentationAgents = useMemo(
+    () => filterAgentsForPresentation(agents, topBarPrefs.showCompletedAgents),
+    [agents, topBarPrefs.showCompletedAgents],
+  );
   const [selectedBuilding, setSelectedBuilding] = useState<{
     id: string;
     anchor: { x: number; y: number };
@@ -33,10 +44,9 @@ export default function App() {
 
   // Only show source badges when both providers have a LIVE agent — completed
   // / error sessions don't count, otherwise the badge would linger after the
-  // last Codex hero finishes just because it's still in state.
-  const liveAgents = agents.filter((a) => a.status !== 'completed' && a.status !== 'error');
-  const showSourceBadge = liveAgents.some((a) => a.source === 'claude')
-    && liveAgents.some((a) => a.source === 'codex');
+  // last Codex hero finishes just because it's still in state. Computed by a
+  // shared helper so VillageScene stays in lockstep.
+  const showSourceBadge = useMemo(() => computeShowSourceBadge(agents), [agents]);
 
   // When selecting agent, clear building
   const handleSelectAgent = useCallback((id: string | null) => {
@@ -103,8 +113,18 @@ export default function App() {
   }, []);
 
   useEffect(() => {
-    eventBridge.emit('agents:updated', agents);
-  }, [agents]);
+    eventBridge.emit('agents:updated', presentationAgents);
+  }, [presentationAgents]);
+
+  // Deselect when the selected agent gets hidden by the presentation projection
+  // (e.g. user flips the "Show completed agents" toggle off while a completed
+  // hero is selected). Without this the DetailPanel would linger pointing at a
+  // hero that is no longer on screen.
+  useEffect(() => {
+    if (selectedAgentId === null) return;
+    const stillVisible = presentationAgents.some((a) => a.id === selectedAgentId);
+    if (!stillVisible) selectAgent(null);
+  }, [presentationAgents, selectedAgentId, selectAgent]);
 
   useEffect(() => {
     eventBridge.emit('selection:changed', selectedAgentId);
@@ -123,10 +143,17 @@ export default function App() {
       <PhaserGame />
       {villageReady && (
         <div className="overlay">
-          <TopBar agents={agents} connected={connected} />
+          <TopBar
+            agents={agents}
+            connected={connected}
+            showCompletedAgents={topBarPrefs.showCompletedAgents}
+            onToggleShowCompletedAgents={() =>
+              updateTopBarPrefs({ showCompletedAgents: !topBarPrefs.showCompletedAgents })
+            }
+          />
           <NoInstallBanner configDirs={configDirs} connected={connected} />
           <PartyBar
-            agents={agents}
+            agents={presentationAgents}
             selectedAgentId={selectedAgentId}
             onSelectAgent={handleSelectAgent}
             showSourceBadge={showSourceBadge}
@@ -138,7 +165,7 @@ export default function App() {
             <BuildingInfoPanel
               buildingId={selectedBuilding.id}
               anchor={selectedBuilding.anchor}
-              agents={agents}
+              agents={presentationAgents}
               onClose={() => setSelectedBuilding(null)}
             />
           )}

--- a/client/src/components/ActivityFeed.tsx
+++ b/client/src/components/ActivityFeed.tsx
@@ -57,9 +57,23 @@ export function ActivityFeed({ log, agents, selectedAgentId, onSelectAgent, show
     return m;
   }, [agents]);
 
+  const STATUS_ORDER: Record<AgentState['status'], number> = {
+    active: 0, waiting: 1, idle: 2, error: 3, completed: 4,
+  };
+  const agentIndexMap = useMemo(() => {
+    const sorted = [...agents].sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status]);
+    const m = new Map<string, number>();
+    sorted.forEach((a, i) => m.set(a.id, i + 1));
+    return m;
+  }, [agents]);
+
   const resolveName = useCallback(
-    (agentId: string) => agentLookup.get(agentId)?.name ?? getAgentNameFallback(agentId),
-    [agentLookup],
+    (agentId: string) => {
+      const name = agentLookup.get(agentId)?.name ?? getAgentNameFallback(agentId);
+      const idx = agentIndexMap.get(agentId);
+      return idx !== undefined ? `${idx}. ${name}` : name;
+    },
+    [agentLookup, agentIndexMap],
   );
 
   // --- Auto-scroll lock + closed-state counter ---

--- a/client/src/components/BuildingInfoPanel.tsx
+++ b/client/src/components/BuildingInfoPanel.tsx
@@ -44,9 +44,10 @@ export function BuildingInfoPanel({ buildingId, anchor, agents, onClose }: Build
 
   if (building === undefined) return null;
 
-  const agentsHere = agents.filter(
-    (a) => a.currentActivity === building.activity && (a.status === 'active' || a.status === 'idle'),
-  );
+  // `agents` is the App-level presentation projection — it already excludes
+  // `error` / `waiting`, and gates `completed` behind the TopBar toggle.
+  // We only need to match this building's activity here.
+  const agentsHere = agents.filter((a) => a.currentActivity === building.activity);
 
   const style = position === null
     ? { visibility: 'hidden' as const }

--- a/client/src/components/PartyBar.css
+++ b/client/src/components/PartyBar.css
@@ -148,6 +148,25 @@
 .partybar-status-overlay.error     { background: #8B2500; }
 .partybar-status-overlay.waiting   { background: #FFD700; }
 
+/* === Index marker (matches the number above the sprite in the village) === */
+.partybar-index {
+  position: absolute;
+  top: -4px;
+  left: -4px;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 4px;
+  border-radius: 4px;
+  background: rgba(0, 0, 0, 0.85);
+  color: #F5E6C8;
+  font: 600 11px/18px 'Fira Code', monospace;
+  text-align: center;
+  border: 1px solid rgba(244, 230, 200, 0.4);
+  box-sizing: border-box;
+  pointer-events: none;
+  z-index: 1;
+}
+
 /* === Row body (Full only) === */
 .partybar-row-body {
   display: flex;

--- a/client/src/components/PartyBar.tsx
+++ b/client/src/components/PartyBar.tsx
@@ -24,13 +24,14 @@ const STATUS_ORDER: Record<AgentState['status'], number> = {
 
 interface PartyRowProps {
   agent: AgentState;
+  index: number;
   mode: 'full' | 'icons';
   isSelected: boolean;
   onClick: () => void;
   showSourceBadge: boolean;
 }
 
-function PartyRow({ agent, mode, isSelected, onClick, showSourceBadge }: PartyRowProps) {
+function PartyRow({ agent, index, mode, isSelected, onClick, showSourceBadge }: PartyRowProps) {
   const [flashing, setFlashing] = useState(false);
   const prevSelected = useRef(isSelected);
 
@@ -65,6 +66,7 @@ function PartyRow({ agent, mode, isSelected, onClick, showSourceBadge }: PartyRo
       title={title}
     >
       <span className="partybar-avatar-wrap">
+        <span className="partybar-index" aria-label={`hero ${index}`}>{index}</span>
         <HeroAvatar agent={agent} size={AVATAR_SIZE} />
         <span className={`partybar-status-overlay ${agent.status}`} aria-hidden="true" />
       </span>
@@ -158,10 +160,11 @@ export function PartyBar({ agents, selectedAgentId, onSelectAgent, showSourceBad
       </div>
 
       <div className="partybar-list">
-        {sorted.map((agent) => (
+        {sorted.map((agent, i) => (
           <PartyRow
             key={agent.id}
             agent={agent}
+            index={i + 1}
             mode={mode}
             isSelected={agent.id === selectedAgentId}
             onClick={() => handleClick(agent.id)}

--- a/client/src/components/PartyBar.tsx
+++ b/client/src/components/PartyBar.tsx
@@ -121,10 +121,13 @@ export function PartyBar({ agents, selectedAgentId, onSelectAgent, showSourceBad
   const [prefs, updatePrefs] = usePartyPrefs();
   const mode: 'full' | 'icons' = prefs.foldState;
 
-  const visible = agents.filter((a) => a.status === 'active' || a.status === 'idle');
-  const sorted = [...visible].sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status]);
-  const activeCount = visible.filter((a) => a.status === 'active').length;
-  const idleCount = visible.filter((a) => a.status === 'idle').length;
+  // `agents` is the App-level presentation projection — it already excludes
+  // `error` / `waiting`, and only includes `completed` when the TopBar toggle
+  // is on. Sort by status (active first) so completed rows land at the bottom.
+  const sorted = [...agents].sort((a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status]);
+  const activeCount = agents.filter((a) => a.status === 'active').length;
+  const idleCount = agents.filter((a) => a.status === 'idle').length;
+  const completedCount = agents.filter((a) => a.status === 'completed').length;
 
   const toggleFold = useCallback(() => {
     updatePrefs({ foldState: mode === 'full' ? 'icons' : 'full' });
@@ -138,9 +141,12 @@ export function PartyBar({ agents, selectedAgentId, onSelectAgent, showSourceBad
     <div className={`partybar mode-${mode}`} role="list" aria-label="Party">
       <div className="partybar-header">
         {mode === 'full' ? (
-          <span className="partybar-title">Party ({activeCount} active, {idleCount} idle)</span>
+          <span className="partybar-title">
+            Party ({activeCount} active, {idleCount} idle
+            {completedCount > 0 ? `, ${completedCount} done` : ''})
+          </span>
         ) : (
-          <span className="partybar-title-compact">{activeCount + idleCount}</span>
+          <span className="partybar-title-compact">{sorted.length}</span>
         )}
         <button
           type="button"

--- a/client/src/components/TopBar.tsx
+++ b/client/src/components/TopBar.tsx
@@ -6,9 +6,16 @@ import './TopBar.css';
 interface TopBarProps {
   agents: AgentState[];
   connected: boolean;
+  showCompletedAgents: boolean;
+  onToggleShowCompletedAgents: () => void;
 }
 
-export function TopBar({ agents, connected }: TopBarProps) {
+export function TopBar({
+  agents,
+  connected,
+  showCompletedAgents,
+  onToggleShowCompletedAgents,
+}: TopBarProps) {
   const active = agents.filter((a) => a.status === 'active').length;
   const idle = agents.filter((a) => a.status === 'idle').length;
   const completed = agents.filter((a) => a.status === 'completed').length;
@@ -116,18 +123,42 @@ export function TopBar({ agents, connected }: TopBarProps) {
 
           <div className="topbar-effects">
             <button
+              type="button"
               className={`topbar-effect-btn ${nightOn ? 'active' : ''}`}
               onClick={toggleNight}
+              aria-pressed={nightOn}
+              aria-label={nightOn ? 'Switch to day mode' : 'Switch to night mode'}
               title={nightOn ? 'Day mode' : 'Night mode'}
             >
               {nightOn ? '\u{1F319}' : '\u{2600}\u{FE0F}'}
             </button>
             <button
+              type="button"
               className={`topbar-effect-btn ${rainOn ? 'active' : ''}`}
               onClick={toggleRain}
+              aria-pressed={rainOn}
+              aria-label={rainOn ? 'Stop rain effect' : 'Start rain effect'}
               title={rainOn ? 'Stop rain' : 'Start rain'}
             >
               {'\u{1F327}\u{FE0F}'}
+            </button>
+            <button
+              type="button"
+              className={`topbar-effect-btn ${showCompletedAgents ? 'active' : ''}`}
+              onClick={onToggleShowCompletedAgents}
+              aria-pressed={showCompletedAgents}
+              aria-label={
+                showCompletedAgents
+                  ? 'Hide completed agents from the village'
+                  : 'Show completed agents in the village'
+              }
+              title={
+                showCompletedAgents
+                  ? 'Hide completed agents'
+                  : 'Show completed agents'
+              }
+            >
+              {showCompletedAgents ? '\u{1F441}\u{FE0F}' : '\u{1F47B}'}
             </button>
             <a
               className="topbar-effect-btn"

--- a/client/src/editor/panels/EditorTopBar.tsx
+++ b/client/src/editor/panels/EditorTopBar.tsx
@@ -1,6 +1,7 @@
 import { editorBridge } from '../EditorBridge';
 import { editorStore, useEditorStore } from '../state/editor-store';
 import type { SlotInfo } from '../types/map';
+import { truncateLabel } from '../../utils/truncateLabel';
 
 export function EditorTopBar() {
   const dirty = useEditorStore((s) => s.dirty);
@@ -57,7 +58,7 @@ export function EditorTopBar() {
   const getSlotLabel = (info: SlotInfo): string => {
     const star = info.isActive ? ' \u2605' : '';
     if (info.isEmpty) return `${info.slot}${star}`;
-    const name = info.name.length > 10 ? info.name.slice(0, 10) + '...' : info.name;
+    const name = truncateLabel(info.name, 10);
     return `${info.slot} \u2014 ${name}${star}`;
   };
 

--- a/client/src/game/PhaserGame.tsx
+++ b/client/src/game/PhaserGame.tsx
@@ -2,24 +2,47 @@ import { useEffect, useRef } from 'react';
 import * as Phaser from 'phaser';
 import { gameConfig } from './config';
 
+// React StrictMode (dev) mounts twice — mount → cleanup → mount. A useRef-per-
+// component pattern lets cleanup destroy() the game before the second mount
+// builds a fresh one, but Phaser's LoaderPlugin keeps in-flight HTTP requests
+// alive past destroy(). Both Phaser.Game instances then fetch the same ~80-file
+// asset batch in parallel, saturate the browser's HTTP/1.1 connection pool,
+// and hang preload at ~31/83.
+//
+// Anchor the game to a module-level slot: the second mount reuses the existing
+// instance and reparents the canvas. Cleanup defers destruction so a fast
+// remount can cancel it. The game tears down only on genuine unmount.
+let liveGame: Phaser.Game | null = null;
+let pendingDestroy: ReturnType<typeof setTimeout> | null = null;
+
 export function PhaserGame() {
   const containerRef = useRef<HTMLDivElement>(null);
-  const gameRef = useRef<Phaser.Game | null>(null);
 
   useEffect(() => {
     if (containerRef.current === null) return;
-    if (gameRef.current !== null) return;
 
-    const game = new Phaser.Game({
-      ...gameConfig,
-      parent: containerRef.current,
-    });
+    if (pendingDestroy !== null) {
+      clearTimeout(pendingDestroy);
+      pendingDestroy = null;
+    }
 
-    gameRef.current = game;
+    if (liveGame === null) {
+      liveGame = new Phaser.Game({
+        ...gameConfig,
+        parent: containerRef.current,
+      });
+    } else if (liveGame.scale.parent !== containerRef.current) {
+      containerRef.current.appendChild(liveGame.canvas);
+      liveGame.scale.parent = containerRef.current;
+      liveGame.scale.refresh();
+    }
 
     return () => {
-      game.destroy(true);
-      gameRef.current = null;
+      pendingDestroy = setTimeout(() => {
+        liveGame?.destroy(true);
+        liveGame = null;
+        pendingDestroy = null;
+      }, 0);
     };
   }, []);
 

--- a/client/src/game/data/building-layout.ts
+++ b/client/src/game/data/building-layout.ts
@@ -28,21 +28,35 @@ export const WORLD_HEIGHT = 1800;
 export const CITY_CLEAR = { x: 1400, y: 780, rx: 520, ry: 420 };
 
 /** Plaza/fountain anchor — drives road hub & heroes' visual centre. */
-export const PLAZA = { x: 1320, y: 790 };
+export const PLAZA = { x: 1400, y: 780 };
 
 /**
- * Organic, non-symmetric placement of the 8 functional buildings. Kept tight
- * (≈700×550 spread) so the whole interactive map is readable without zoom-out.
+ * Buildings placed in workflow order so hero movement follows the natural
+ * handle-issue flow: spawn(Gate) → reading → thinking → editing ⇄ bash ⇄
+ * debugging → git → reviewing → idle.
+ *
+ * Key layout decisions:
+ * - Library (reading) and Castle (thinking) sit near the south gate so the
+ *   first steps of a new task require minimal travel.
+ * - Forge (editing), Arena (bash), and Alchemist (debugging) form a tight
+ *   central cluster — the three most frequent mutual transitions stay close.
+ * - Chapel (git) and Watchtower (reviewing) share the north-east corner,
+ *   representing the late-stage commit/review phase.
+ * - Tavern (idle) anchors the western plaza so waiting heroes don't clutter
+ *   the active work zone.
+ *
+ * All coordinates lie inside the CITY_CLEAR ellipse (centre 1400,780;
+ * rx=520, ry=420).
  */
 export const BUILDING_DEFS: BuildingDef[] = [
-  { id: 'library',    label: 'Library',    activity: 'reading',   x: 1060, y: 600,  imageKey: 'building-library',    scale: 0.52, description: 'Agents come here to read and search code',                toolCalls: ['Read', 'Grep', 'Glob'] },
-  { id: 'alchemist',  label: 'Alchemist',  activity: 'debugging', x: 1210, y: 460,  imageKey: 'building-alchemist',  scale: 0.50, description: 'Agents come here to debug and fix errors',                toolCalls: ['(fixing after errors)'] },
-  { id: 'castle',     label: 'Castle',     activity: 'thinking',  x: 1430, y: 430,  imageKey: 'building-castle',     scale: 0.46, description: 'Agents come here to think and reason',                    toolCalls: ['(AI thinking/planning)'] },
-  { id: 'watchtower', label: 'Watchtower', activity: 'reviewing', x: 1650, y: 470,  imageKey: 'building-watchtower', scale: 0.42, description: 'Agents come here to review code and dispatch subagents',  toolCalls: ['Agent', 'review'] },
-  { id: 'chapel',     label: 'Chapel',     activity: 'git',       x: 1790, y: 610,  imageKey: 'building-chapel',     scale: 0.38, description: 'Agents come here to commit and push code',                toolCalls: ['git commit', 'git push', 'git merge'] },
-  { id: 'tavern',     label: 'Tavern',     activity: 'idle',      x: 1510, y: 810,  imageKey: 'building-tavern',     scale: 0.50, description: 'Agents rest here while waiting for user input',           toolCalls: ['(idle/waiting)'] },
-  { id: 'forge',      label: 'Forge',      activity: 'editing',   x: 1150, y: 970,  imageKey: 'building-forge',      scale: 0.42, description: 'Agents come here to write and edit code',                 toolCalls: ['Edit', 'Write'] },
-  { id: 'arena',      label: 'Arena',      activity: 'bash',      x: 1700, y: 970,  imageKey: 'building-arena',      scale: 0.42, description: 'Agents come here to run commands and tests',              toolCalls: ['Bash'] },
+  { id: 'library',    label: 'Library',    activity: 'reading',   x: 1150, y: 900,  imageKey: 'building-library',    scale: 0.52, description: 'Agents come here to read and search code',                toolCalls: ['Read', 'Grep', 'Glob'] },
+  { id: 'castle',     label: 'Castle',     activity: 'thinking',  x: 1300, y: 700,  imageKey: 'building-castle',     scale: 0.46, description: 'Agents come here to think and reason',                    toolCalls: ['(AI thinking/planning)'] },
+  { id: 'forge',      label: 'Forge',      activity: 'editing',   x: 1380, y: 880,  imageKey: 'building-forge',      scale: 0.42, description: 'Agents come here to write and edit code',                 toolCalls: ['Edit', 'Write'] },
+  { id: 'arena',      label: 'Arena',      activity: 'bash',      x: 1560, y: 880,  imageKey: 'building-arena',      scale: 0.42, description: 'Agents come here to run commands and tests',              toolCalls: ['Bash'] },
+  { id: 'alchemist',  label: 'Alchemist',  activity: 'debugging', x: 1470, y: 700,  imageKey: 'building-alchemist',  scale: 0.50, description: 'Agents come here to debug and fix errors',                toolCalls: ['(fixing after errors)'] },
+  { id: 'chapel',     label: 'Chapel',     activity: 'git',       x: 1720, y: 560,  imageKey: 'building-chapel',     scale: 0.38, description: 'Agents come here to commit and push code',                toolCalls: ['git commit', 'git push', 'git merge'] },
+  { id: 'watchtower', label: 'Watchtower', activity: 'reviewing', x: 1600, y: 450,  imageKey: 'building-watchtower', scale: 0.42, description: 'Agents come here to review code and dispatch subagents',  toolCalls: ['Agent', 'review'] },
+  { id: 'tavern',     label: 'Tavern',     activity: 'idle',      x: 1250, y: 780,  imageKey: 'building-tavern',     scale: 0.50, description: 'Agents rest here while waiting for user input',           toolCalls: ['(idle/waiting)'] },
 ];
 
 /** South gate — where heroes first spawn before walking into the village. */

--- a/client/src/game/data/building-layout.ts
+++ b/client/src/game/data/building-layout.ts
@@ -31,22 +31,17 @@ export const CITY_CLEAR = { x: 1400, y: 780, rx: 520, ry: 420 };
 export const PLAZA = { x: 1400, y: 780 };
 
 /**
- * Buildings placed in workflow order so hero movement follows the natural
- * handle-issue flow: spawn(Gate) → reading → thinking → editing ⇄ bash ⇄
- * debugging → git → reviewing → idle.
+ * Building coordinates follow the handle-issue workflow order to minimise hero
+ * travel distance on the transitions that happen most often in practice:
  *
- * Key layout decisions:
- * - Library (reading) and Castle (thinking) sit near the south gate so the
- *   first steps of a new task require minimal travel.
- * - Forge (editing), Arena (bash), and Alchemist (debugging) form a tight
- *   central cluster — the three most frequent mutual transitions stay close.
- * - Chapel (git) and Watchtower (reviewing) share the north-east corner,
- *   representing the late-stage commit/review phase.
- * - Tavern (idle) anchors the western plaza so waiting heroes don't clutter
- *   the active work zone.
- *
- * All coordinates lie inside the CITY_CLEAR ellipse (centre 1400,780;
- * rx=520, ry=420).
+ * - Forge/Arena/Alchemist cluster tightly (≤ 201 px apart) because editing,
+ *   running tests, and debugging cycle rapidly within a single task step.
+ * - Library and Castle sit near the south gate so the first two steps of every
+ *   task (read codebase, plan) require short walks from the spawn point.
+ * - Chapel and Watchtower share the north-east corner because git operations
+ *   and code review happen together at end-of-task, keeping that flow local.
+ * - Tavern occupies the western plaza so idle heroes stay out of the active
+ *   work zone and are visually distinct from agents in progress.
  */
 export const BUILDING_DEFS: BuildingDef[] = [
   { id: 'library',    label: 'Library',    activity: 'reading',   x: 1150, y: 900,  imageKey: 'building-library',    scale: 0.52, description: 'Agents come here to read and search code',                toolCalls: ['Read', 'Grep', 'Glob'] },

--- a/client/src/game/data/road-network.ts
+++ b/client/src/game/data/road-network.ts
@@ -4,40 +4,47 @@ export interface Point {
 }
 
 /**
- * Compact organic village waypoints. The interactive map hugs a ~750×550
- * area centred near (1400, 720) — all agents' functional targets are within
- * view at default zoom.
+ * Road network aligned with the handle-issue workflow order so heroes travel
+ * in a coherent direction rather than zigzagging across the village.
+ *
+ * Flow: Gate(0) → south-junction(1) → center(3) → north-junction(5)
+ *       with lateral spurs reaching each building cluster:
+ *         • Library spur:   1 → 6
+ *         • Plaza/Tavern:   2 ↔ 3
+ *         • East/Bash:      3 → 4
+ *         • Edit↔Bash↔Debug triangle: 3 ↔ 8, 4 ↔ 8
+ *         • Thinking spur:  5 → 7
+ *         • Git/Review:     5 → 9 → 10
  */
 const DEFAULT_WAYPOINTS: Point[] = [
   { x: 1400, y: 1130 }, // 0  gate
-  { x: 1400, y: 1000 }, // 1  south-junction
-  { x: 1320, y: 790 },  // 2  plaza
-  { x: 1430, y: 560 },  // 3  north-junction
-  { x: 1130, y: 790 },  // 4  west-junction
-  { x: 1680, y: 790 },  // 5  east-junction
-  { x: 1150, y: 560 },  // 6  nw-corner
-  { x: 1660, y: 560 },  // 7  ne-corner
-  { x: 1150, y: 1000 }, // 8  sw-corner
-  { x: 1680, y: 1000 }, // 9  se-corner
-  { x: 1040, y: 680 },  // 10 library-access
-  { x: 1790, y: 680 },  // 11 chapel-access
-  { x: 1430, y: 490 },  // 12 castle-access
+  { x: 1380, y: 960 },  // 1  south-junction (gateway to library and center)
+  { x: 1250, y: 780 },  // 2  plaza / tavern hub (west)
+  { x: 1400, y: 780 },  // 3  center-junction (editing cluster hub)
+  { x: 1540, y: 780 },  // 4  east-junction (bash area)
+  { x: 1400, y: 600 },  // 5  north-junction (thinking / git branch)
+  { x: 1150, y: 900 },  // 6  library-access (reading)
+  { x: 1300, y: 700 },  // 7  castle-access (thinking)
+  { x: 1470, y: 700 },  // 8  alchemist-access (debugging)
+  { x: 1720, y: 560 },  // 9  chapel-access (git)
+  { x: 1600, y: 450 },  // 10 watchtower-access (reviewing)
 ];
 
 const DEFAULT_EDGES: [number, number][] = [
   // N-S main spine
-  [0, 1], [1, 2], [2, 3],
-  // E-W through plaza
-  [2, 4], [2, 5],
-  // Corner diagonals (non-grid feel)
-  [1, 8], [1, 9],
-  [3, 6], [3, 7],
-  [4, 6], [4, 8],
-  [5, 7], [5, 9],
-  // Short spurs
-  [6, 10], [4, 10],
-  [7, 11], [5, 11],
-  [3, 12],
+  [0, 1], [1, 3], [3, 5],
+  // Library spur (reading — first stop after gate)
+  [1, 6],
+  // E-W through center
+  [2, 3], [3, 4],
+  // Editing ↔ Bash ↔ Debug tight triangle
+  [3, 8], [4, 8],
+  // Thinking spur
+  [5, 7],
+  // Debug from north (test-fail loop)
+  [5, 8],
+  // Git / review branch
+  [5, 9], [9, 10],
 ];
 
 // ---------------------------------------------------------------------------
@@ -290,7 +297,8 @@ export function findRoadPath(from: Point, to: Point): Point[] {
 
 /** Exposed so TerrainRenderer can paint roads along the same network. */
 export function getRoadSegments(): Array<{ a: Point; b: Point; main: boolean }> {
-  const mainEdges = new Set(['0-1', '1-2', '2-3']);
+  // Main spine: gate(0)→south-junction(1)→center(3)→north-junction(5)
+  const mainEdges = new Set(['0-1', '1-3', '3-5']);
   const result: Array<{ a: Point; b: Point; main: boolean }> = [];
   for (const [a, b] of activeEdges) {
     const key = `${Math.min(a, b)}-${Math.max(a, b)}`;

--- a/client/src/game/data/road-network.ts
+++ b/client/src/game/data/road-network.ts
@@ -7,27 +7,31 @@ export interface Point {
  * Road network aligned with the handle-issue workflow order so heroes travel
  * in a coherent direction rather than zigzagging across the village.
  *
- * Flow: Gate(0) → south-junction(1) → center(3) → north-junction(5)
- *       with lateral spurs reaching each building cluster:
- *         • Library spur:   1 → 6
- *         • Plaza/Tavern:   2 ↔ 3
- *         • East/Bash:      3 → 4
- *         • Edit↔Bash↔Debug triangle: 3 ↔ 8, 4 ↔ 8
- *         • Thinking spur:  5 → 7
- *         • Git/Review:     5 → 9 → 10
+ * Spine: Gate(0) → south-junction(1) → center(3) → north-junction(5)
+ * Spurs to each building's access node:
+ *   • Library:   1 → 6        (reading — first stop after spawn)
+ *   • Tavern:    2 ↔ 3        (idle — western plaza)
+ *   • Forge:     3 → 11       (editing)
+ *   • Arena:     4 → 12       (bash)
+ *   • Debug triangle: 11 ↔ 12, 11 ↔ 8, 12 ↔ 8   (edit/bash/debug cluster)
+ *   • Castle:    5 → 7        (thinking)
+ *   • Chapel:    5 → 9        (git)
+ *   • Watchtower: 9 → 10      (reviewing)
  */
 const DEFAULT_WAYPOINTS: Point[] = [
   { x: 1400, y: 1130 }, // 0  gate
   { x: 1380, y: 960 },  // 1  south-junction (gateway to library and center)
   { x: 1250, y: 780 },  // 2  plaza / tavern hub (west)
-  { x: 1400, y: 780 },  // 3  center-junction (editing cluster hub)
-  { x: 1540, y: 780 },  // 4  east-junction (bash area)
+  { x: 1400, y: 780 },  // 3  center-junction
+  { x: 1540, y: 780 },  // 4  east-junction
   { x: 1400, y: 600 },  // 5  north-junction (thinking / git branch)
   { x: 1150, y: 900 },  // 6  library-access (reading)
   { x: 1300, y: 700 },  // 7  castle-access (thinking)
   { x: 1470, y: 700 },  // 8  alchemist-access (debugging)
   { x: 1720, y: 560 },  // 9  chapel-access (git)
   { x: 1600, y: 450 },  // 10 watchtower-access (reviewing)
+  { x: 1380, y: 880 },  // 11 forge-access (editing) — matches BUILDING_DEFS
+  { x: 1560, y: 880 },  // 12 arena-access (bash)   — matches BUILDING_DEFS
 ];
 
 const DEFAULT_EDGES: [number, number][] = [
@@ -35,10 +39,12 @@ const DEFAULT_EDGES: [number, number][] = [
   [0, 1], [1, 3], [3, 5],
   // Library spur (reading — first stop after gate)
   [1, 6],
-  // E-W through center
+  // E-W through center to east
   [2, 3], [3, 4],
-  // Editing ↔ Bash ↔ Debug tight triangle
-  [3, 8], [4, 8],
+  // Editing and bash access from their junctions
+  [3, 11], [4, 12],
+  // Editing ↔ Bash ↔ Debug tight triangle (most frequent mutual transitions)
+  [11, 12], [11, 8], [12, 8],
   // Thinking spur
   [5, 7],
   // Debug from north (test-fail loop)
@@ -296,10 +302,10 @@ export function findRoadPath(from: Point, to: Point): Point[] {
 }
 
 /** Exposed so TerrainRenderer can paint roads along the same network. */
-export function getRoadSegments(): Array<{ a: Point; b: Point; main: boolean }> {
+export function getRoadSegments(): Array<{ a: Readonly<Point>; b: Readonly<Point>; main: boolean }> {
   // Main spine: gate(0)→south-junction(1)→center(3)→north-junction(5)
   const mainEdges = new Set(['0-1', '1-3', '3-5']);
-  const result: Array<{ a: Point; b: Point; main: boolean }> = [];
+  const result: Array<{ a: Readonly<Point>; b: Readonly<Point>; main: boolean }> = [];
   for (const [a, b] of activeEdges) {
     const key = `${Math.min(a, b)}-${Math.max(a, b)}`;
     result.push({ a: activeWaypoints[a]!, b: activeWaypoints[b]!, main: mainEdges.has(key) });

--- a/client/src/game/entities/Building.ts
+++ b/client/src/game/entities/Building.ts
@@ -48,28 +48,16 @@ export class Building {
     // Y-based depth: use doorY (bottom edge) so heroes sort correctly
     this.image.setDepth(this.doorY);
 
-    // Label above building — image top is at y - displayHeight (since origin is bottom)
+    // Activity label above building — shows what heroes do here (THINKING,
+    // EDITING, etc.) instead of the building's proper name. Cleaner for PiP.
     const labelY = def.y - this.image.displayHeight - 8;
-    const labelFont = "'Cinzel', serif";
-    this.label = addCrispText(scene, def.x, labelY, def.label, {
-      fontSize: '15px',
+    this.label = addCrispText(scene, def.x, labelY, def.activity.toUpperCase(), {
+      fontSize: '17px',
       fontStyle: '600',
       color: '#F5E6C8',
-      fontFamily: labelFont,
-      stroke: '#000000',
-      strokeThickness: 2,
-      shadow: { offsetX: 0, offsetY: 1, color: '#000', blur: 3, fill: true },
+      fontFamily: "'Fira Code', monospace",
+      backgroundColor: 'rgba(0,0,0,0.6)',
+      padding: { x: 6, y: 3 },
     }).setOrigin(0.5, 1).setDepth(this.doorY + 0.1);
-
-    // Subtitle (description) below the label — pushed 5px down to clear the
-    // title's descenders and avoid muddiness in the overlap zone.
-    addCrispText(scene, def.x, labelY + 5, def.activity, {
-      fontSize: '11px',
-      color: '#d8d8d8',
-      fontFamily: labelFont,
-      stroke: '#000000',
-      strokeThickness: 1,
-      shadow: { offsetX: 0, offsetY: 1, color: '#000', blur: 2, fill: true },
-    }).setOrigin(0.5, 0).setDepth(this.doorY + 0.1);
   }
 }

--- a/client/src/game/entities/Building.ts
+++ b/client/src/game/entities/Building.ts
@@ -50,7 +50,7 @@ export class Building {
 
     // Label above building — image top is at y - displayHeight (since origin is bottom)
     const labelY = def.y - this.image.displayHeight - 8;
-    const labelFont = '"Inter", system-ui, -apple-system, "Segoe UI", sans-serif';
+    const labelFont = "'Cinzel', serif";
     this.label = addCrispText(scene, def.x, labelY, def.label, {
       fontSize: '15px',
       fontStyle: '600',

--- a/client/src/game/entities/HeroSprite.ts
+++ b/client/src/game/entities/HeroSprite.ts
@@ -1,5 +1,5 @@
 import * as Phaser from 'phaser';
-import { HERO_COLOR_SPRITE_BASE, HERO_LABEL_COLOR, SOURCE_BADGE_COLOR, modelBadge, type HeroClass, type HeroColor, type AgentActivity, type AgentSource, type AgentState } from '../../types/agent';
+import { HERO_COLOR_SPRITE_BASE, HERO_LABEL_COLOR, type HeroClass, type HeroColor, type AgentActivity, type AgentSource, type AgentState } from '../../types/agent';
 import { getActiveTheme } from '../themes/registry';
 import { findRoadPath, type Point } from '../data/road-network';
 import { addCrispText } from '../text';
@@ -10,12 +10,10 @@ const MOVE_SPEED = 150;
 /** Ground distance covered by one full run-cycle. Keeps legs synced to travel. */
 const RUN_PIXELS_PER_CYCLE = 60;
 
-/**
- * Label offsets are computed per-instance from the sprite's actual
- * displayHeight so they adapt to whatever scale the active theme uses.
- * The formulas below reproduce the original Tiny Swords values
- * (sprite 96 px → name -50, activity +46, detail +60, task +74).
- */
+/** Truncation caps — short so labels stay inside the sprite's visual footprint. */
+const NAME_MAX_CHARS = 18;
+const TASK_MAX_CHARS = 22;
+const ACTIVITY_MSG_MAX_CHARS = 22;
 
 const ACTIVITY_COLOR: Record<AgentActivity, string> = {
   idle:      '#888888',
@@ -32,15 +30,14 @@ const WAITING_COLOR = '#FFD700';
 const ERROR_COLOR = '#FF4444';
 const ERROR_WINDOW_MS = 90 * 1000;
 
+const LABEL_BG = 'rgba(0,0,0,0.65)';
+const LABEL_PAD = { x: 4, y: 2 };
+const BUBBLE_TASK_COLOR = '#3D1F00';
+const BUBBLE_MSG_COLOR = '#6B4226';
+const INDEX_COLOR = '#F5E6C8';
+
 const HALO_TEXTURE_KEY = 'hero-selection-halo';
 
-/**
- * Lazily build a soft radial-gradient texture we can reuse as the selection
- * halo. Cached in Phaser's global TextureManager for the lifetime of the
- * game — scenes share it via the same key. The gradient fades white →
- * transparent so the glow blends with the scene instead of looking like a
- * flat disc.
- */
 function ensureHaloTexture(scene: Phaser.Scene): void {
   if (scene.textures.exists(HALO_TEXTURE_KEY)) return;
   const size = 128;
@@ -59,6 +56,20 @@ function ensureHaloTexture(scene: Phaser.Scene): void {
   tex.refresh();
 }
 
+/**
+ * On-sprite label IA (issue #16):
+ *
+ *   [N]                      ← indexText (top-right of sprite, matches PartyBar number)
+ *   [task line]              ← taskText (above head, yellow, user prompt)
+ *   [activity message]       ← activityMsgText (below taskText, gray, last Activity Feed message)
+ *   [SPRITE]
+ *   [hero name]              ← nameText (below feet, 2 lines, color reflects activity)
+ *   [name line 2]
+ *
+ * Everything else (subagent marker, source/model badge, separate activity word
+ * label) lives in PartyBar — that's the single place to look for per-hero
+ * metadata so the canvas stays uncluttered.
+ */
 export class HeroSprite {
   readonly id: string;
   readonly heroClass: HeroClass;
@@ -66,7 +77,11 @@ export class HeroSprite {
   private sprite: Phaser.GameObjects.Sprite;
   private source: AgentSource;
   private isSubagent: boolean;
-  private activityText: Phaser.GameObjects.Text;
+  private nameText: Phaser.GameObjects.Text;
+  private taskText: Phaser.GameObjects.Text;
+  private activityMsgText: Phaser.GameObjects.Text;
+  private bubbleBg: Phaser.GameObjects.Graphics;
+  private indexText: Phaser.GameObjects.Text;
   private _x: number;
   private _y: number;
   private moveTween: Phaser.Tweens.Tween | null = null;
@@ -75,7 +90,11 @@ export class HeroSprite {
   private idleKey: string;
   private runKey: string;
   private facesLeft: boolean;
-  private activityOffsetY: number;
+  private nameOffsetY: number;
+  private taskOffsetY: number;
+  private activityMsgOffsetY: number;
+  private indexOffsetX: number;
+  private indexOffsetY: number;
   currentActivity: AgentActivity = 'idle';
   private isWaiting = false;
   private isErrorRecent = false;
@@ -107,34 +126,36 @@ export class HeroSprite {
     this._y = y;
 
     const theme = getActiveTheme();
-    // Map the logical hero color to a sprite base the theme actually ships
-    // with. Extra palette entries (teal/orange/green) share the sprite of
-    // their base color — only the label (name tag) gets the expanded color,
-    // the sprite itself is never recolored.
     const spriteBase = HERO_COLOR_SPRITE_BASE[heroColor];
     const cfg = theme.getHeroConfig(spriteBase, heroClass);
     this.idleKey = cfg.idleKey;
     this.runKey = cfg.runKey;
     this.facesLeft = cfg.facesLeft;
 
-    // Create sprite with idle animation. Sub-agents render at a
-    // smaller scale so the eye reads them as companions/helpers of the
-    // main hero — see `computeSpriteScale` for the rule.
     this.sprite = scene.add.sprite(x, y, this.idleKey);
     this.sprite.setScale(computeSpriteScale(theme.heroScale, isSubagent));
-    // Flip sprites that natively face left so they face right by default
     this.sprite.setFlipX(this.facesLeft);
     if (cfg.tint !== null) this.sprite.setTint(cfg.tint);
-    // Tag at construction time so the scene-level background-click
-    // detector (VillageScene) can classify pointerdown hits correctly
-    // regardless of which code path later wires up interactivity.
     this.sprite.setData('isHero', true);
 
-    // Activity label offset: just below the sprite's feet.
     const halfH = this.sprite.displayHeight / 2;
-    this.activityOffsetY = halfH - 2;
+    const halfW = this.sprite.displayWidth / 2;
 
-    // Create idle animation if it doesn't exist yet
+    // Above-head bubble — sits right at the head so the bubble's tail looks
+    // like it grows out of the sprite. The gap between sprite and bubble was
+    // ~16 px before; pulling it in to ~2 px reads as direct speech.
+    this.activityMsgOffsetY = -(halfH - 16);
+    this.taskOffsetY = this.activityMsgOffsetY - 13;
+
+    // Below-feet name (2 lines). Tiny Swords CC0 sprites have ~8 px of
+    // transparent padding below the character's feet inside the frame, so
+    // the visual foot line is well above the frame's mathematical bottom.
+    this.nameOffsetY = halfH - 24;
+
+    // Index marker — top-left of the sprite, snug against the head.
+    this.indexOffsetX = -(halfW - 38);
+    this.indexOffsetY = -(halfH - 28);
+
     const idleAnimKey = `${this.idleKey}-anim`;
     if (!scene.anims.exists(idleAnimKey)) {
       const idleFrameSpec = cfg.idleFrameIndices !== undefined
@@ -150,7 +171,6 @@ export class HeroSprite {
 
     const runAnimKey = `${this.runKey}-anim`;
     if (!scene.anims.exists(runAnimKey)) {
-      // Match frame rate to ground speed so legs don't float or drag.
       const runFrameRate = cfg.runFrames * (MOVE_SPEED / RUN_PIXELS_PER_CYCLE);
       const runFrameSpec = cfg.runFrameIndices !== undefined
         ? { frames: cfg.runFrameIndices }
@@ -165,76 +185,95 @@ export class HeroSprite {
 
     this.sprite.play(idleAnimKey);
 
-    // Activity label is the only text rendered on the sprite — one label per
-    // hero keeps the canvas readable when 5–10 characters are visible at once.
-    // Name, model, source, detail and task all live in the Party Bar / Detail Panel.
-    this.activityText = addCrispText(scene, x, y + this.activityOffsetY, 'idle', {
-      fontSize: '11px',
-      color: ACTIVITY_COLOR.idle,
-      fontFamily: "'Fira Code', monospace",
-      backgroundColor: 'rgba(0,0,0,0.65)',
-      padding: { x: 4, y: 2 },
-    }).setOrigin(0.5);
+    const nameColor = HERO_LABEL_COLOR[heroColor] ?? '#DDDDDD';
+    this.nameBaseColor = nameColor;
 
-    // Set initial Y-based depth
+    // Hero name — below feet, wraps to 2 lines for long display names.
+    this.nameText = addCrispText(scene, x, y + this.nameOffsetY, truncateLabel(name, NAME_MAX_CHARS), {
+      fontSize: '11px',
+      color: nameColor,
+      fontFamily: "'Fira Code', monospace",
+      backgroundColor: LABEL_BG,
+      padding: LABEL_PAD,
+      align: 'center',
+    }).setOrigin(0.5, 0);
+
+    // Speech bubble — Graphics plate (rounded rect + tail) holds both text lines.
+    // The plate is sized in `updateBubble()` after the texts have rasterized so
+    // its width tracks the widest line.
+    this.bubbleBg = scene.add.graphics();
+    this.bubbleBg.setVisible(false);
+
+    this.taskText = addCrispText(scene, x, y + this.taskOffsetY, '', {
+      fontSize: '10px',
+      color: BUBBLE_TASK_COLOR,
+      fontFamily: "'Fira Code', monospace",
+      align: 'center',
+    }).setOrigin(0.5, 1).setVisible(false);
+
+    this.activityMsgText = addCrispText(scene, x, y + this.activityMsgOffsetY, '', {
+      fontSize: '10px',
+      color: BUBBLE_MSG_COLOR,
+      fontFamily: "'Fira Code', monospace",
+      align: 'center',
+    }).setOrigin(0.5, 1).setVisible(false);
+
+    // Index marker — sits to the left of the name on the same row. `setOrigin(1, 0)`
+    // anchors its right edge to the position so it grows leftward; the actual x is
+    // sprite-left-edge minus a 2px gap.
+    this.indexText = addCrispText(scene, x + this.indexOffsetX, y + this.indexOffsetY, '', {
+      fontSize: '10px',
+      color: INDEX_COLOR,
+      fontFamily: "'Fira Code', monospace",
+      backgroundColor: 'rgba(0,0,0,0.8)',
+      padding: { x: 3, y: 1 },
+      align: 'center',
+    }).setOrigin(1, 0).setVisible(false);
+
+    this.setBubbleAlpha(1.0);
     this.updateDepth();
+  }
+
+  private setBubbleAlpha(alpha: number): void {
+    this.bubbleBg.setAlpha(alpha);
+    this.taskText.setAlpha(alpha);
+    this.activityMsgText.setAlpha(alpha);
   }
 
   get x(): number { return this._x; }
   get y(): number { return this._y; }
 
-  /**
-   * Override the default hero scale (e.g. from MapConfig settings).
-   * Sub-agent factor is preserved — passing `1.5` on a sub-agent yields an
-   * effective sprite scale of `1.5 * SUBAGENT_SCALE_FACTOR`.
-   */
   setHeroScale(scale: number): void {
     this.sprite.setScale(computeSpriteScale(scale, this.isSubagent));
   }
 
-  /**
-   * Teleport the hero (sprite + every overlay text) to a new position. Used
-   * by the scene to keep attached sub-agents stuck to their parent — these
-   * sprites bypass the road-network tween path entirely and follow parent
-   * position frame to frame.
-   */
+  /** Teleport sprite + every label to (x, y). */
   teleportTo(x: number, y: number): void {
     this._x = x;
     this._y = y;
     this.sprite.setPosition(x, y);
     this.nameText.setPosition(x, y + this.nameOffsetY);
-    this.layoutSubagentAndSource();
-    this.layoutActivityAndModel();
-    this.detailText.setPosition(x, y + this.detailOffsetY);
     this.taskText.setPosition(x, y + this.taskOffsetY);
+    this.activityMsgText.setPosition(x, y + this.activityMsgOffsetY);
+    this.indexText.setPosition(x + this.indexOffsetX, y + this.indexOffsetY);
+    this.updateBubble();
     if (this.selectionHalo !== null) {
       this.selectionHalo.setPosition(x, y);
     }
     this.updateDepth();
   }
 
-  /** Whether this hero represents a sub-agent (visual companion). */
   getIsSubagent(): boolean {
     return this.isSubagent;
   }
 
-  /** Make the sprite respond to pointerdown with the supplied callback. */
   setInteractiveForSelection(onClick: () => void): void {
     if (!this.sprite.input || !this.sprite.input.enabled) {
       this.sprite.setInteractive({ useHandCursor: true });
     }
-    // The `isHero` tag is set in the constructor so it's present even for
-    // spawn paths that never call this method.
     this.sprite.on('pointerdown', onClick);
   }
 
-  /**
-   * Apply or clear a selection visual: a pulsing blue halo BEHIND the sprite
-   * (alpha + scale yoyo ~1s cycle). The sprite itself stays untinted so the
-   * character's natural colors are preserved; only the surrounding light
-   * pulses. The name text is brightened so the selected hero's label stands
-   * out against its neighbors.
-   */
   setSelected(selected: boolean): void {
     if (this.selectionTween !== null) {
       this.selectionTween.stop();
@@ -252,10 +291,6 @@ export class HeroSprite {
       halo.setAlpha(0.35);
       halo.setDepth(this.sprite.depth - 0.1);
       this.selectionHalo = halo;
-      // Capture the baseline scale AFTER setDisplaySize so the tween
-      // yoyos between this fixed baseline and baseline × peak factor.
-      // Using halo.scaleX directly in the tween target would be the
-      // same math but reads as if the scale were self-referential.
       const baseScale = halo.scaleX;
       this.selectionTween = this.scene.tweens.add({
         targets: halo,
@@ -268,20 +303,29 @@ export class HeroSprite {
         ease: 'Sine.easeInOut',
       });
       this.nameText.setColor('#FFFFFF');
-      this.nameText.setStroke('#1E5FA3', 5);
+      this.setBubbleAlpha(1.0);
     } else {
-      this.nameText.setColor(this.nameBaseColor);
-      this.nameText.setStroke('#000000', 3);
+      this.refreshNameColor();
+      this.setBubbleAlpha(1.0);
     }
   }
 
-  /** Update the displayed activity label and internal state. */
-  setActivity(activity: AgentActivity): void {
-    this.currentActivity = activity;
-    this.refreshActivityVisual();
+  /** Reflect activity / waiting / error state in the name color (single visual signal). */
+  private refreshNameColor(): void {
+    if (this.isErrorRecent) {
+      this.nameText.setColor(ERROR_COLOR);
+    } else if (this.isWaiting) {
+      this.nameText.setColor(WAITING_COLOR);
+    } else {
+      this.nameText.setColor(ACTIVITY_COLOR[this.currentActivity] ?? this.nameBaseColor);
+    }
   }
 
-  /** Apply status-driven overlays (e.g. 'waiting' pulses gold). */
+  setActivity(activity: AgentActivity): void {
+    this.currentActivity = activity;
+    this.refreshNameColor();
+  }
+
   setStatus(status: AgentState['status']): void {
     const wantsWaiting = status === 'waiting';
     if (wantsWaiting && !this.isWaiting) {
@@ -291,10 +335,9 @@ export class HeroSprite {
       this.isWaiting = false;
       this.stopWaitingPulse();
     }
-    this.refreshActivityVisual();
+    this.refreshNameColor();
   }
 
-  /** Apply recent-error overlay; auto-clears after ERROR_WINDOW_MS from the given timestamp. */
   setErrorTimestamp(ts: number | undefined): void {
     if (this.errorTimer !== null) {
       this.errorTimer.remove();
@@ -302,43 +345,28 @@ export class HeroSprite {
     }
     if (ts === undefined) {
       this.isErrorRecent = false;
-      this.refreshActivityVisual();
+      this.refreshNameColor();
       return;
     }
     const age = Date.now() - ts;
     if (age >= ERROR_WINDOW_MS) {
       this.isErrorRecent = false;
-      this.refreshActivityVisual();
+      this.refreshNameColor();
       return;
     }
     this.isErrorRecent = true;
-    this.refreshActivityVisual();
+    this.refreshNameColor();
     this.errorTimer = this.scene.time.delayedCall(ERROR_WINDOW_MS - age, () => {
       this.isErrorRecent = false;
       this.errorTimer = null;
-      this.refreshActivityVisual();
+      this.refreshNameColor();
     });
-  }
-
-  private refreshActivityVisual(): void {
-    if (this.isErrorRecent) {
-      this.activityText.setText('error');
-      this.activityText.setColor(ERROR_COLOR);
-    } else if (this.isWaiting) {
-      this.activityText.setText('waiting…');
-      this.activityText.setColor(WAITING_COLOR);
-    } else {
-      this.activityText.setText(this.currentActivity);
-      this.activityText.setColor(ACTIVITY_COLOR[this.currentActivity]);
-    }
-    // Text width changed → re-center the activity/model pair on the hero.
-    this.layoutActivityAndModel();
   }
 
   private startWaitingPulse(): void {
     if (this.waitingTween !== null) return;
     this.waitingTween = this.scene.tweens.add({
-      targets: this.activityText,
+      targets: this.nameText,
       alpha: { from: 1, to: 0.45 },
       duration: 700,
       ease: 'Sine.easeInOut',
@@ -352,188 +380,152 @@ export class HeroSprite {
       this.waitingTween.stop();
       this.waitingTween = null;
     }
-    this.activityText.setAlpha(1);
+    this.nameText.setAlpha(1);
   }
 
-  /** Update depth of sprite and labels based on Y position (Y-sorting). */
   private updateDepth(): void {
-    // Sort by the hero's FEET, not its center, so the pivot matches buildings
-    // (bottom-anchored, origin 0.5/1) and decorations that sort on their base.
-    // Without this, a hero whose feet align with a building's foot would render
-    // behind it because his center-y is well above the building's foot-y.
     const footY = this._y + this.sprite.displayHeight * 0.5;
     this.sprite.setDepth(footY + 0.5);
-    this.nameText.setDepth(footY + 0.6);
-    if (this.subagentText !== null) this.subagentText.setDepth(footY + 0.6);
-    if (this.sourceText !== null) this.sourceText.setDepth(footY + 0.6);
-    this.activityText.setDepth(footY + 0.6);
-    if (this.modelText !== null) this.modelText.setDepth(footY + 0.6);
-    this.detailText.setDepth(footY + 0.6);
-    this.taskText.setDepth(footY + 0.6);
+    // Labels render above buildings (buildings sort by their foot-y too,
+    // so footY + 1 puts hero labels in front of any building at the same row).
+    this.nameText.setDepth(footY + 1.1);
+    this.bubbleBg.setDepth(footY + 1.0);
+    this.taskText.setDepth(footY + 1.1);
+    this.activityMsgText.setDepth(footY + 1.1);
+    this.indexText.setDepth(footY + 1.2);
     if (this.selectionHalo !== null) this.selectionHalo.setDepth(footY + 0.4);
   }
 
   /**
-   * Show or hide the source badge (`CODEX` / `CLAUDE`). Called by the scene
-   * whenever the fleet's provider makeup changes. Lazily creates the Text
-   * object on first reveal. When a subagent marker is already present, the
-   * two labels sit side-by-side on the subagent row; otherwise the badge sits
-   * alone on that row.
+   * Redraw the speech-bubble plate behind taskText + activityMsgText, sized
+   * to whichever lines are currently visible. Called on every text/visibility
+   * change. Hides the plate when both lines are empty.
    */
-  setSourceBadgeVisible(visible: boolean): void {
-    this.sourceBadgeVisible = visible;
-    const justCreated = visible && this.sourceText === null;
-    if (justCreated) {
-      this.sourceText = addCrispText(
-        this.scene,
-        this._x,
-        this._y + this.subagentOffsetY,
-        this.source.toUpperCase(),
-        {
-          fontSize: '9px',
-          color: SOURCE_BADGE_COLOR[this.source],
-          fontFamily: "'Fira Code', monospace",
-          stroke: '#000000',
-          strokeThickness: 2,
-        },
-      );
-    }
-    if (this.sourceText !== null) {
-      this.sourceText.setVisible(visible);
-    }
-    this.layoutSubagentAndSource();
-    // A hero parked at its building has no active move tween, so the text
-    // would keep its default depth (0) and render behind buildings until the
-    // next move. Force a depth sweep so the new badge is visible immediately.
-    if (justCreated) this.updateDepth();
-  }
-
-  /**
-   * Position the subagent marker and source badge on the shared subagent row.
-   * When both are visible they sit side-by-side (centered as a pair); when
-   * only one is visible it sits centered on its own.
-   */
-  private layoutSubagentAndSource(): void {
-    const y = this._y + this.subagentOffsetY;
-    if (this.sourceBadgeVisible && this.isSubagent && this.subagentText !== null && this.sourceText !== null) {
-      this.subagentText.setOrigin(1, 0.5);
-      this.subagentText.setPosition(this._x - 3, y);
-      this.sourceText.setOrigin(0, 0.5);
-      this.sourceText.setPosition(this._x + 3, y);
+  private updateBubble(): void {
+    const taskVisible = this.taskText.visible && this.taskText.text.length > 0;
+    const msgVisible = this.activityMsgText.visible && this.activityMsgText.text.length > 0;
+    this.bubbleBg.clear();
+    if (!taskVisible && !msgVisible) {
+      this.bubbleBg.setVisible(false);
       return;
     }
-    if (this.subagentText !== null) {
-      this.subagentText.setOrigin(0.5);
-      this.subagentText.setPosition(this._x, y);
+    const padX = 6;
+    const padY = 4;
+
+    // Derive plate bounds from the actual text positions + display sizes.
+    // Both texts use origin (0.5, 1) — their anchor is bottom-center, so:
+    //   textTop    = text.y - text.displayHeight
+    //   textBottom = text.y
+    const texts: Phaser.GameObjects.Text[] = [];
+    if (taskVisible) texts.push(this.taskText);
+    if (msgVisible) texts.push(this.activityMsgText);
+
+    let minTop = Infinity;
+    let maxBottom = -Infinity;
+    let maxWidth = 0;
+    for (const t of texts) {
+      const tTop = t.y - t.displayHeight;
+      const tBottom = t.y;
+      if (tTop < minTop) minTop = tTop;
+      if (tBottom > maxBottom) maxBottom = tBottom;
+      if (t.displayWidth > maxWidth) maxWidth = t.displayWidth;
     }
-    if (this.sourceText !== null) {
-      this.sourceText.setOrigin(0.5);
-      this.sourceText.setPosition(this._x, y);
-    }
+
+    const w = maxWidth + padX * 2;
+    const top = minTop - padY;
+    const bottom = maxBottom + padY;
+    const h = bottom - top;
+    const cx = this._x;
+    const left = cx - w / 2;
+
+    // Parchment-style speech bubble: warm cream fill + dark brown border.
+    this.bubbleBg.fillStyle(0xF5E0B0, 0.92);
+    this.bubbleBg.fillRoundedRect(left, top, w, h, 9);
+    this.bubbleBg.lineStyle(2, 0x8B5E3C, 0.9);
+    this.bubbleBg.strokeRoundedRect(left, top, w, h, 9);
+
+    // Tail — triangle pointing down toward the sprite's head.
+    const tailW = 10;
+    const tailH = 8;
+    // Fill tail with parchment color first, then draw border edges.
+    this.bubbleBg.fillStyle(0xF5E0B0, 0.92);
+    this.bubbleBg.beginPath();
+    this.bubbleBg.moveTo(cx - tailW / 2, bottom);
+    this.bubbleBg.lineTo(cx + tailW / 2, bottom);
+    this.bubbleBg.lineTo(cx, bottom + tailH);
+    this.bubbleBg.closePath();
+    this.bubbleBg.fillPath();
+    // Border on the two exposed tail edges (left-diagonal + right-diagonal).
+    this.bubbleBg.lineStyle(2, 0x8B5E3C, 0.9);
+    this.bubbleBg.beginPath();
+    this.bubbleBg.moveTo(cx - tailW / 2, bottom);
+    this.bubbleBg.lineTo(cx, bottom + tailH);
+    this.bubbleBg.lineTo(cx + tailW / 2, bottom);
+    this.bubbleBg.strokePath();
+    this.bubbleBg.setVisible(true);
   }
 
-  /**
-   * Show the model badge (e.g. `OPUS`, `SONNET`) next to the activity label on
-   * the row below the hero. Pass `undefined` to hide/destroy it. Called by the
-   * scene whenever the agent's model changes (mid-session switches included).
-   */
-  setModel(modelId: string | undefined): void {
-    const badge = modelBadge(modelId);
-    if (badge === null) {
-      if (this.modelText !== null) {
-        this.modelText.destroy();
-        this.modelText = null;
-        this.layoutActivityAndModel();
-      }
-      return;
-    }
-    if (this.modelText === null) {
-      this.modelText = addCrispText(
-        this.scene,
-        this._x,
-        this._y + this.activityOffsetY,
-        badge.short,
-        {
-          fontSize: '11px',
-          color: badge.color,
-          fontFamily: "'Fira Code', monospace",
-          fontStyle: 'bold',
-          stroke: '#000000',
-          strokeThickness: 2,
-        },
-      );
-      // New text object: give it the hero's current depth so it renders above
-      // buildings even before the next tween tick re-runs updateDepth().
-      this.updateDepth();
-    } else {
-      this.modelText.setText(badge.short);
-      this.modelText.setColor(badge.color);
-    }
-    this.layoutActivityAndModel();
+  /** Source / model badges and subagent markers live in PartyBar now — these are no-ops kept for caller compatibility. */
+  setSourceBadgeVisible(_visible: boolean): void {
+    // intentionally empty
   }
 
-  /**
-   * Center the activity label — plus the model badge when present — as a
-   * group on the hero's x axis, sharing the activityOffsetY row. A 6 px gap
-   * separates the two so they read as "activity · MODEL" without gluing.
-   */
-  private layoutActivityAndModel(): void {
-    const y = this._y + this.activityOffsetY;
-    if (this.modelText === null) {
-      this.activityText.setOrigin(0.5, 0.5);
-      this.activityText.setPosition(this._x, y);
-      return;
-    }
-    const gap = 6;
-    const widthA = this.activityText.displayWidth;
-    const widthM = this.modelText.displayWidth;
-    const leftEdge = this._x - (widthA + gap + widthM) / 2;
-    this.activityText.setOrigin(0, 0.5);
-    this.activityText.setPosition(leftEdge, y);
-    this.modelText.setOrigin(0, 0.5);
-    this.modelText.setPosition(leftEdge + widthA + gap, y);
+  setModel(_modelId: string | undefined): void {
+    // intentionally empty
   }
 
-  /**
-   * Update the name label above the hero. Truncates with an ellipsis when the
-   * label exceeds NAME_MAX_CHARS so the rest of the head stack (subagent
-   * marker, activity, detail, task) stays inside the hero's visual footprint.
-   * No-op when `name` matches what's already rendered (avoids touching the
-   * Phaser text object on every WebSocket tick).
-   */
+  /** Update the hero name label. */
   updateName(name: string): void {
     const truncated = truncateLabel(name, NAME_MAX_CHARS);
     if (this.nameText.text === truncated) return;
     this.nameText.setText(truncated);
   }
 
-  /** Update the truncated task line shown below the detail. */
+  /** Update the task line of the head bubble (user's last prompt). Pass undefined/empty to hide. */
   updateTask(task?: string): void {
     if (task === undefined || task.length === 0) {
       this.taskText.setText('');
-      return;
+      this.taskText.setVisible(false);
+    } else {
+      this.taskText.setText(truncateLabel(task, TASK_MAX_CHARS));
+      this.taskText.setVisible(true);
     }
-    this.taskText.setText(truncateLabel(task, TASK_MAX_CHARS));
+    this.updateBubble();
   }
 
-  /** Update the detail line shown below the activity label. */
+  /** Update the activity-feed message line (last tool call / message). Pass undefined/empty to hide. */
   updateDetail(file?: string, command?: string): void {
     let detail = '';
-    if (file) {
-      // Show only the filename, not the full path
+    if (command !== undefined && command.length > 0) {
+      detail = truncateLabel(command, ACTIVITY_MSG_MAX_CHARS);
+    } else if (file !== undefined && file.length > 0) {
       const parts = file.split('/');
       detail = parts[parts.length - 1] ?? file;
-    } else if (command) {
-      detail = truncateLabel(command, 25);
     }
-    this.detailText.setText(detail);
+    if (detail.length === 0) {
+      this.activityMsgText.setText('');
+      this.activityMsgText.setVisible(false);
+    } else {
+      this.activityMsgText.setText(detail);
+      this.activityMsgText.setVisible(true);
+    }
+    this.updateBubble();
+  }
+
+  /** Set the party index marker. Pass undefined to hide. */
+  setIndex(index: number | undefined): void {
+    if (index === undefined) {
+      this.indexText.setVisible(false);
+      return;
+    }
+    this.indexText.setText(String(index));
+    this.indexText.setVisible(true);
   }
 
   moveTo(targetX: number, targetY: number, activity: AgentActivity): void {
     this.currentActivity = activity;
-    this.refreshActivityVisual();
+    this.refreshNameColor();
 
-    // Cancel existing move
     if (this.moveTween !== null) {
       this.moveTween.stop();
       this.moveTween = null;
@@ -541,7 +533,6 @@ export class HeroSprite {
 
     const path = findRoadPath({ x: this._x, y: this._y }, { x: targetX, y: targetY });
 
-    // Remove the first point (current position)
     if (path.length > 1) {
       path.shift();
     }
@@ -575,7 +566,6 @@ export class HeroSprite {
       return;
     }
 
-    // Flip based on horizontal direction (invert for sprites that natively face left)
     if (Math.abs(dx) > 5) {
       this.sprite.setFlipX((dx < 0) !== this.facesLeft);
     }
@@ -595,10 +585,10 @@ export class HeroSprite {
         this._y = target.y;
         this.sprite.setPosition(this._x, this._y);
         this.nameText.setPosition(this._x, this._y + this.nameOffsetY);
-        this.layoutSubagentAndSource();
-        this.layoutActivityAndModel();
-        this.detailText.setPosition(this._x, this._y + this.detailOffsetY);
         this.taskText.setPosition(this._x, this._y + this.taskOffsetY);
+        this.activityMsgText.setPosition(this._x, this._y + this.activityMsgOffsetY);
+        this.indexText.setPosition(this._x + this.indexOffsetX, this._y + this.indexOffsetY);
+        this.updateBubble();
         if (this.selectionHalo !== null) {
           this.selectionHalo.setPosition(this._x, this._y);
         }
@@ -636,11 +626,9 @@ export class HeroSprite {
     }
     this.sprite.destroy();
     this.nameText.destroy();
-    if (this.subagentText !== null) this.subagentText.destroy();
-    if (this.sourceText !== null) this.sourceText.destroy();
-    this.activityText.destroy();
-    if (this.modelText !== null) this.modelText.destroy();
-    this.detailText.destroy();
+    this.bubbleBg.destroy();
     this.taskText.destroy();
+    this.activityMsgText.destroy();
+    this.indexText.destroy();
   }
 }

--- a/client/src/game/entities/HeroSprite.ts
+++ b/client/src/game/entities/HeroSprite.ts
@@ -103,6 +103,15 @@ export class HeroSprite {
   private selectionHalo: Phaser.GameObjects.Image | null = null;
   private wanderTimer: Phaser.Time.TimerEvent | null = null;
 
+  /**
+   * Sub-agent visual distinction markers. Null for main-session heroes.
+   * - `subagentGlowRing`: pulsing circular outline drawn around the sprite
+   * - `subagentIconText`: small ⚙ badge at the sprite's top-right corner
+   */
+  private subagentGlowRing: Phaser.GameObjects.Graphics | null = null;
+  private subagentIconText: Phaser.GameObjects.Text | null = null;
+  private subagentGlowTween: Phaser.Tweens.Tween | null = null;
+
   /** Grid base position — used for slot repositioning. */
   gridBaseX = 0;
   gridBaseY = 0;
@@ -236,6 +245,105 @@ export class HeroSprite {
 
     this.setBubbleAlpha(1.0);
     this.updateDepth();
+
+    if (isSubagent) {
+      this.initSubagentMarkers();
+    }
+  }
+
+  /**
+   * Create the sub-agent glow ring and gear-icon badge that distinguish
+   * sub-agent sprites from main-session heroes in the village view.
+   *
+   * Called once from the constructor when `isSubagent` is true.
+   * The glow ring pulses via a looping alpha tween so it catches the eye
+   * even in a dense scene. The badge renders as a tiny ⚙ symbol at the
+   * sprite's top-right corner.
+   */
+  private initSubagentMarkers(): void {
+    const radius = this.sprite.displayWidth * 0.55;
+
+    // Glow ring — drawn as a filled transparent circle so the stroke appears
+    // on top of the sprite rather than underneath it. A pulsing tween drives
+    // alpha between 0.35 and 0.8, giving a "breathing" glow effect.
+    this.subagentGlowRing = this.scene.add.graphics();
+    this.drawSubagentGlowRing(radius, 0.55);
+
+    this.subagentGlowTween = this.scene.tweens.add({
+      targets: this.subagentGlowRing,
+      alpha: { from: 0.35, to: 0.8 },
+      duration: 1200,
+      yoyo: true,
+      repeat: -1,
+      ease: 'Sine.easeInOut',
+    });
+
+    // Gear-icon badge — small text label at top-right so it reads like a
+    // status indicator without needing a custom texture asset.
+    this.subagentIconText = addCrispText(
+      this.scene,
+      this._x,
+      this._y,
+      '⚙',
+      {
+        fontSize: '10px',
+        color: '#c8a8ff',
+        fontFamily: 'monospace',
+        backgroundColor: 'rgba(20,10,40,0.75)',
+        padding: { x: 2, y: 1 },
+      },
+    ).setOrigin(0, 1);
+
+    // Position markers and depth after creation so they respect the hero's
+    // initial position set in the constructor.
+    this.repositionSubagentMarkers();
+    this.updateSubagentMarkerDepth();
+  }
+
+  /**
+   * Redraw the glow ring graphics at the hero's current screen position.
+   * Called whenever the hero moves or its scale changes.
+   */
+  private drawSubagentGlowRing(radius: number, alpha: number): void {
+    if (this.subagentGlowRing === null) return;
+    this.subagentGlowRing.clear();
+    this.subagentGlowRing.lineStyle(2, 0x9b72cf, alpha);
+    this.subagentGlowRing.strokeCircle(this._x, this._y, radius);
+  }
+
+  /** Move the glow ring and icon badge to the hero's current world position. */
+  private repositionSubagentMarkers(): void {
+    if (this.subagentGlowRing === null && this.subagentIconText === null) return;
+
+    const radius = this.sprite.displayWidth * 0.55;
+
+    if (this.subagentGlowRing !== null) {
+      // Graphics objects draw in world space — clear and redraw at new position.
+      this.subagentGlowRing.clear();
+      this.subagentGlowRing.lineStyle(2, 0x9b72cf, 1.0);
+      this.subagentGlowRing.strokeCircle(this._x, this._y, radius);
+    }
+
+    if (this.subagentIconText !== null) {
+      // Badge sits at top-right of the sprite footprint.
+      const badgeOffsetX = this.sprite.displayWidth * 0.4;
+      const badgeOffsetY = -(this.sprite.displayHeight * 0.4);
+      this.subagentIconText.setPosition(
+        this._x + badgeOffsetX,
+        this._y + badgeOffsetY,
+      );
+    }
+  }
+
+  /** Sync sub-agent marker depth with the sprite so they render above the ground. */
+  private updateSubagentMarkerDepth(): void {
+    const footY = this._y + this.sprite.displayHeight * 0.5;
+    if (this.subagentGlowRing !== null) {
+      this.subagentGlowRing.setDepth(footY + 0.45);
+    }
+    if (this.subagentIconText !== null) {
+      this.subagentIconText.setDepth(footY + 1.3);
+    }
   }
 
   private setBubbleAlpha(alpha: number): void {
@@ -263,6 +371,9 @@ export class HeroSprite {
     this.updateBubble();
     if (this.selectionHalo !== null) {
       this.selectionHalo.setPosition(x, y);
+    }
+    if (this.isSubagent) {
+      this.repositionSubagentMarkers();
     }
     this.updateDepth();
   }
@@ -480,6 +591,9 @@ export class HeroSprite {
     this.activityMsgText.setDepth(footY + 1.1);
     this.indexText.setDepth(footY + 1.2);
     if (this.selectionHalo !== null) this.selectionHalo.setDepth(footY + 0.4);
+    if (this.isSubagent) {
+      this.updateSubagentMarkerDepth();
+    }
   }
 
   /**
@@ -678,6 +792,9 @@ export class HeroSprite {
         if (this.selectionHalo !== null) {
           this.selectionHalo.setPosition(this._x, this._y);
         }
+        if (this.isSubagent) {
+          this.repositionSubagentMarkers();
+        }
         this.updateDepth();
       },
       onComplete: () => {
@@ -710,6 +827,18 @@ export class HeroSprite {
     if (this.selectionHalo !== null) {
       this.selectionHalo.destroy();
       this.selectionHalo = null;
+    }
+    if (this.subagentGlowTween !== null) {
+      this.subagentGlowTween.stop();
+      this.subagentGlowTween = null;
+    }
+    if (this.subagentGlowRing !== null) {
+      this.subagentGlowRing.destroy();
+      this.subagentGlowRing = null;
+    }
+    if (this.subagentIconText !== null) {
+      this.subagentIconText.destroy();
+      this.subagentIconText = null;
     }
     this.sprite.destroy();
     this.nameText.destroy();

--- a/client/src/game/entities/HeroSprite.ts
+++ b/client/src/game/entities/HeroSprite.ts
@@ -4,6 +4,7 @@ import { getActiveTheme } from '../themes/registry';
 import { findRoadPath, type Point } from '../data/road-network';
 import { addCrispText } from '../text';
 import { truncateLabel } from '../../utils/truncateLabel';
+import { computeSpriteScale } from './hero-scale';
 
 const MOVE_SPEED = 150;
 /** Ground distance covered by one full run-cycle. Keeps legs synced to travel. */
@@ -136,9 +137,11 @@ export class HeroSprite {
     this.runKey = cfg.runKey;
     this.facesLeft = cfg.facesLeft;
 
-    // Create sprite with idle animation
+    // Create sprite with idle animation. Sub-agents render at a
+    // smaller scale so the eye reads them as companions/helpers of the
+    // main hero — see `computeSpriteScale` for the rule.
     this.sprite = scene.add.sprite(x, y, this.idleKey);
-    this.sprite.setScale(theme.heroScale);
+    this.sprite.setScale(computeSpriteScale(theme.heroScale, isSubagent));
     // Flip sprites that natively face left so they face right by default
     this.sprite.setFlipX(this.facesLeft);
     if (cfg.tint !== null) this.sprite.setTint(cfg.tint);
@@ -249,9 +252,39 @@ export class HeroSprite {
   get x(): number { return this._x; }
   get y(): number { return this._y; }
 
-  /** Override the default hero scale (e.g. from MapConfig settings). */
+  /**
+   * Override the default hero scale (e.g. from MapConfig settings).
+   * Sub-agent factor is preserved — passing `1.5` on a sub-agent yields an
+   * effective sprite scale of `1.5 * SUBAGENT_SCALE_FACTOR`.
+   */
   setHeroScale(scale: number): void {
-    this.sprite.setScale(scale);
+    this.sprite.setScale(computeSpriteScale(scale, this.isSubagent));
+  }
+
+  /**
+   * Teleport the hero (sprite + every overlay text) to a new position. Used
+   * by the scene to keep attached sub-agents stuck to their parent — these
+   * sprites bypass the road-network tween path entirely and follow parent
+   * position frame to frame.
+   */
+  teleportTo(x: number, y: number): void {
+    this._x = x;
+    this._y = y;
+    this.sprite.setPosition(x, y);
+    this.nameText.setPosition(x, y + this.nameOffsetY);
+    this.layoutSubagentAndSource();
+    this.layoutActivityAndModel();
+    this.detailText.setPosition(x, y + this.detailOffsetY);
+    this.taskText.setPosition(x, y + this.taskOffsetY);
+    if (this.selectionHalo !== null) {
+      this.selectionHalo.setPosition(x, y);
+    }
+    this.updateDepth();
+  }
+
+  /** Whether this hero represents a sub-agent (visual companion). */
+  getIsSubagent(): boolean {
+    return this.isSubagent;
   }
 
   /** Make the sprite respond to pointerdown with the supplied callback. */

--- a/client/src/game/entities/HeroSprite.ts
+++ b/client/src/game/entities/HeroSprite.ts
@@ -12,8 +12,8 @@ const RUN_PIXELS_PER_CYCLE = 60;
 
 /** Truncation caps — short so labels stay inside the sprite's visual footprint. */
 const NAME_MAX_CHARS = 18;
-const TASK_MAX_CHARS = 22;
-const ACTIVITY_MSG_MAX_CHARS = 22;
+const TASK_MAX_CHARS = 44;
+const ACTIVITY_MSG_MAX_CHARS = 44;
 
 const ACTIVITY_COLOR: Record<AgentActivity, string> = {
   idle:      '#888888',
@@ -32,8 +32,8 @@ const ERROR_WINDOW_MS = 90 * 1000;
 
 const LABEL_BG = 'rgba(0,0,0,0.65)';
 const LABEL_PAD = { x: 4, y: 2 };
-const BUBBLE_TASK_COLOR = '#3D1F00';
-const BUBBLE_MSG_COLOR = '#6B4226';
+const BUBBLE_TASK_COLOR = '#3D1F00';   // user command — dark brown, dominant
+const BUBBLE_MSG_COLOR = '#8C6A4A';   // system feedback — mid brown, recessive
 const INDEX_COLOR = '#F5E6C8';
 
 const HALO_TEXTURE_KEY = 'hero-selection-halo';
@@ -144,7 +144,7 @@ export class HeroSprite {
     // Above-head bubble — sits right at the head so the bubble's tail looks
     // like it grows out of the sprite. The gap between sprite and bubble was
     // ~16 px before; pulling it in to ~2 px reads as direct speech.
-    this.activityMsgOffsetY = -(halfH - 16);
+    this.activityMsgOffsetY = -(halfH - 24);
     this.taskOffsetY = this.activityMsgOffsetY - 13;
 
     // Below-feet name (2 lines). Tiny Swords CC0 sprites have ~8 px of
@@ -205,17 +205,20 @@ export class HeroSprite {
     this.bubbleBg.setVisible(false);
 
     this.taskText = addCrispText(scene, x, y + this.taskOffsetY, '', {
-      fontSize: '10px',
+      fontSize: '11px',
+      fontStyle: 'bold',
       color: BUBBLE_TASK_COLOR,
       fontFamily: "'Fira Code', monospace",
       align: 'center',
+      wordWrap: { width: 140 },
     }).setOrigin(0.5, 1).setVisible(false);
 
     this.activityMsgText = addCrispText(scene, x, y + this.activityMsgOffsetY, '', {
-      fontSize: '10px',
+      fontSize: '9px',
       color: BUBBLE_MSG_COLOR,
       fontFamily: "'Fira Code', monospace",
       align: 'center',
+      wordWrap: { width: 140 },
     }).setOrigin(0.5, 1).setVisible(false);
 
     // Index marker — sits to the left of the name on the same row. `setOrigin(1, 0)`

--- a/client/src/game/entities/HeroSprite.ts
+++ b/client/src/game/entities/HeroSprite.ts
@@ -3,6 +3,7 @@ import { HERO_COLOR_SPRITE_BASE, HERO_LABEL_COLOR, SOURCE_BADGE_COLOR, modelBadg
 import { getActiveTheme } from '../themes/registry';
 import { findRoadPath, type Point } from '../data/road-network';
 import { addCrispText } from '../text';
+import { truncateLabel } from '../../utils/truncateLabel';
 
 const MOVE_SPEED = 150;
 /** Ground distance covered by one full run-cycle. Keeps legs synced to travel. */
@@ -15,6 +16,13 @@ const RUN_PIXELS_PER_CYCLE = 60;
  * (sprite 96 px → name -50, activity +46, detail +60, task +74).
  */
 const TASK_MAX_CHARS = 28;
+/**
+ * Hero head labels mirror the user's `cc_session_step` output —
+ * `[#1234, 12/13] some long description`. Cap roughly matches Claude Code's
+ * own `agents` view column so the label stays readable above the sprite
+ * without bleeding into adjacent heroes.
+ */
+const NAME_MAX_CHARS = 40;
 
 const ACTIVITY_COLOR: Record<AgentActivity, string> = {
   idle:      '#888888',
@@ -182,7 +190,7 @@ export class HeroSprite {
 
     const nameColor = HERO_LABEL_COLOR[heroColor] ?? '#DDDDDD';
     this.nameBaseColor = nameColor;
-    this.nameText = addCrispText(scene, x, y + this.nameOffsetY, name, {
+    this.nameText = addCrispText(scene, x, y + this.nameOffsetY, truncateLabel(name, NAME_MAX_CHARS), {
       fontSize: '14px',
       color: nameColor,
       fontFamily: 'monospace',
@@ -522,17 +530,26 @@ export class HeroSprite {
     this.modelText.setPosition(leftEdge + widthA + gap, y);
   }
 
+  /**
+   * Update the name label above the hero. Truncates with an ellipsis when the
+   * label exceeds NAME_MAX_CHARS so the rest of the head stack (subagent
+   * marker, activity, detail, task) stays inside the hero's visual footprint.
+   * No-op when `name` matches what's already rendered (avoids touching the
+   * Phaser text object on every WebSocket tick).
+   */
+  updateName(name: string): void {
+    const truncated = truncateLabel(name, NAME_MAX_CHARS);
+    if (this.nameText.text === truncated) return;
+    this.nameText.setText(truncated);
+  }
+
   /** Update the truncated task line shown below the detail. */
   updateTask(task?: string): void {
     if (task === undefined || task.length === 0) {
       this.taskText.setText('');
       return;
     }
-    const single = task.replace(/\s+/g, ' ').trim();
-    const text = single.length > TASK_MAX_CHARS
-      ? single.slice(0, TASK_MAX_CHARS - 1) + '\u2026'
-      : single;
-    this.taskText.setText(text);
+    this.taskText.setText(truncateLabel(task, TASK_MAX_CHARS));
   }
 
   /** Update the detail line shown below the activity label. */
@@ -543,7 +560,7 @@ export class HeroSprite {
       const parts = file.split('/');
       detail = parts[parts.length - 1] ?? file;
     } else if (command) {
-      detail = command.length > 25 ? command.slice(0, 24) + '\u2026' : command;
+      detail = truncateLabel(command, 25);
     }
     this.detailText.setText(detail);
   }

--- a/client/src/game/entities/HeroSprite.ts
+++ b/client/src/game/entities/HeroSprite.ts
@@ -75,7 +75,6 @@ export class HeroSprite {
   readonly heroClass: HeroClass;
   private scene: Phaser.Scene;
   private sprite: Phaser.GameObjects.Sprite;
-  private source: AgentSource;
   private isSubagent: boolean;
   private nameText: Phaser.GameObjects.Text;
   private taskText: Phaser.GameObjects.Text;
@@ -125,12 +124,11 @@ export class HeroSprite {
     x: number,
     y: number,
     isSubagent = false,
-    source: AgentSource = 'claude',
+    _source: AgentSource = 'claude',
   ) {
     this.scene = scene;
     this.id = id;
     this.heroClass = heroClass;
-    this.source = source;
     this.isSubagent = isSubagent;
     this._x = x;
     this._y = y;
@@ -525,6 +523,9 @@ export class HeroSprite {
         this.indexText.setPosition(this._x + this.indexOffsetX, this._y + this.indexOffsetY);
         this.updateBubble();
         if (this.selectionHalo !== null) this.selectionHalo.setPosition(this._x, this._y);
+        if (this.isSubagent) {
+          this.repositionSubagentMarkers();
+        }
         this.updateDepth();
       },
       onComplete: () => {

--- a/client/src/game/entities/HeroSprite.ts
+++ b/client/src/game/entities/HeroSprite.ts
@@ -101,6 +101,7 @@ export class HeroSprite {
   private nameBaseColor = '#DDDDDD';
   private selectionTween: Phaser.Tweens.Tween | null = null;
   private selectionHalo: Phaser.GameObjects.Image | null = null;
+  private wanderTimer: Phaser.Time.TimerEvent | null = null;
 
   /** Grid base position — used for slot repositioning. */
   gridBaseX = 0;
@@ -325,8 +326,14 @@ export class HeroSprite {
   }
 
   setActivity(activity: AgentActivity): void {
+    const wasIdle = this.currentActivity === 'idle';
     this.currentActivity = activity;
     this.refreshNameColor();
+    if (activity === 'idle' && !wasIdle) {
+      this.startIdleWander();
+    } else if (activity !== 'idle' && wasIdle) {
+      this.stopIdleWander();
+    }
   }
 
   setStatus(status: AgentState['status']): void {
@@ -338,7 +345,83 @@ export class HeroSprite {
       this.isWaiting = false;
       this.stopWaitingPulse();
     }
+    if (status === 'completed') {
+      this.stopIdleWander();
+      this.playCompletionVFX();
+    }
     this.refreshNameColor();
+  }
+
+  private playCompletionVFX(): void {
+    const emitter = this.scene.add.particles(this._x, this._y - 10, 'px', {
+      speed: { min: 30, max: 80 },
+      scale: { start: 2, end: 0 },
+      alpha: { start: 1, end: 0 },
+      tint: [0xFFD700, 0xFFA500, 0xFFFF00],
+      lifespan: 800,
+      quantity: 12,
+      emitting: false,
+    });
+    emitter.explode(12);
+    emitter.setDepth(this.sprite.depth + 1);
+    this.scene.time.delayedCall(1000, () => emitter.destroy());
+  }
+
+  private startIdleWander(): void {
+    if (this.wanderTimer !== null) return;
+    this.scheduleNextWander();
+  }
+
+  private stopIdleWander(): void {
+    if (this.wanderTimer !== null) {
+      this.wanderTimer.remove();
+      this.wanderTimer = null;
+    }
+  }
+
+  private scheduleNextWander(): void {
+    const delay = Phaser.Math.Between(3000, 7000);
+    this.wanderTimer = this.scene.time.delayedCall(delay, () => {
+      this.wanderTimer = null;
+      if (this.currentActivity !== 'idle' || this.moveTween !== null) return;
+      const offsetX = Phaser.Math.Between(-12, 12);
+      const offsetY = Phaser.Math.Between(-8, 8);
+      this.wanderTo(this.gridBaseX + offsetX, this.gridBaseY + offsetY);
+    });
+  }
+
+  private wanderTo(targetX: number, targetY: number): void {
+    const dx = targetX - this._x;
+    const dy = targetY - this._y;
+    const distance = Math.sqrt(dx * dx + dy * dy);
+    if (distance < 3) { this.scheduleNextWander(); return; }
+    if (Math.abs(dx) > 3) this.sprite.setFlipX((dx < 0) !== this.facesLeft);
+    this.sprite.play(`${this.runKey}-anim`, true);
+    const duration = (distance / 60) * 1000;
+    this.moveTween = this.scene.tweens.add({
+      targets: { x: this._x, y: this._y },
+      x: targetX,
+      y: targetY,
+      duration,
+      ease: 'Linear',
+      onUpdate: (_tween, target: { x: number; y: number }) => {
+        this._x = target.x;
+        this._y = target.y;
+        this.sprite.setPosition(this._x, this._y);
+        this.nameText.setPosition(this._x, this._y + this.nameOffsetY);
+        this.taskText.setPosition(this._x, this._y + this.taskOffsetY);
+        this.activityMsgText.setPosition(this._x, this._y + this.activityMsgOffsetY);
+        this.indexText.setPosition(this._x + this.indexOffsetX, this._y + this.indexOffsetY);
+        this.updateBubble();
+        if (this.selectionHalo !== null) this.selectionHalo.setPosition(this._x, this._y);
+        this.updateDepth();
+      },
+      onComplete: () => {
+        this.moveTween = null;
+        this.sprite.play(`${this.idleKey}-anim`, true);
+        this.scheduleNextWander();
+      },
+    });
   }
 
   setErrorTimestamp(ts: number | undefined): void {
@@ -615,6 +698,7 @@ export class HeroSprite {
       this.waitingTween.stop();
       this.waitingTween = null;
     }
+    this.stopIdleWander();
     if (this.errorTimer !== null) {
       this.errorTimer.remove();
       this.errorTimer = null;

--- a/client/src/game/entities/HeroSprite.ts
+++ b/client/src/game/entities/HeroSprite.ts
@@ -16,14 +16,6 @@ const RUN_PIXELS_PER_CYCLE = 60;
  * The formulas below reproduce the original Tiny Swords values
  * (sprite 96 px → name -50, activity +46, detail +60, task +74).
  */
-const TASK_MAX_CHARS = 28;
-/**
- * Hero head labels mirror the user's `cc_session_step` output —
- * `[#1234, 12/13] some long description`. Cap roughly matches Claude Code's
- * own `agents` view column so the label stays readable above the sprite
- * without bleeding into adjacent heroes.
- */
-const NAME_MAX_CHARS = 40;
 
 const ACTIVITY_COLOR: Record<AgentActivity, string> = {
   idle:      '#888888',
@@ -72,17 +64,9 @@ export class HeroSprite {
   readonly heroClass: HeroClass;
   private scene: Phaser.Scene;
   private sprite: Phaser.GameObjects.Sprite;
-  private nameText: Phaser.GameObjects.Text;
-  private subagentText: Phaser.GameObjects.Text | null = null;
-  private sourceText: Phaser.GameObjects.Text | null = null;
   private source: AgentSource;
   private isSubagent: boolean;
-  private sourceBadgeVisible = false;
   private activityText: Phaser.GameObjects.Text;
-  /** Lazily created when a model badge applies (Claude sessions only). */
-  private modelText: Phaser.GameObjects.Text | null = null;
-  private detailText: Phaser.GameObjects.Text;
-  private taskText: Phaser.GameObjects.Text;
   private _x: number;
   private _y: number;
   private moveTween: Phaser.Tweens.Tween | null = null;
@@ -91,11 +75,7 @@ export class HeroSprite {
   private idleKey: string;
   private runKey: string;
   private facesLeft: boolean;
-  private nameOffsetY: number;
-  private subagentOffsetY: number;
   private activityOffsetY: number;
-  private detailOffsetY: number;
-  private taskOffsetY: number;
   currentActivity: AgentActivity = 'idle';
   private isWaiting = false;
   private isErrorRecent = false;
@@ -150,15 +130,9 @@ export class HeroSprite {
     // regardless of which code path later wires up interactivity.
     this.sprite.setData('isHero', true);
 
-    // Label offsets derived from actual sprite height — scale with theme.
+    // Activity label offset: just below the sprite's feet.
     const halfH = this.sprite.displayHeight / 2;
-    this.nameOffsetY = -(halfH + 2);
-    // Subagent marker sits ~16px below the name (standard "subtitle" placement,
-    // so the name stays the primary anchor for the eye).
-    this.subagentOffsetY = this.nameOffsetY + 16;
     this.activityOffsetY = halfH - 2;
-    this.detailOffsetY = halfH + 12;
-    this.taskOffsetY = halfH + 26;
 
     // Create idle animation if it doesn't exist yet
     const idleAnimKey = `${this.idleKey}-anim`;
@@ -191,58 +165,15 @@ export class HeroSprite {
 
     this.sprite.play(idleAnimKey);
 
-    const nameColor = HERO_LABEL_COLOR[heroColor] ?? '#DDDDDD';
-    this.nameBaseColor = nameColor;
-    this.nameText = addCrispText(scene, x, y + this.nameOffsetY, truncateLabel(name, NAME_MAX_CHARS), {
-      fontSize: '14px',
-      color: nameColor,
-      fontFamily: 'monospace',
-      stroke: '#000000',
-      strokeThickness: 3,
-    }).setOrigin(0.5);
-
-    // Subagent marker: only created for spawned subagents — sits just above
-    // the name to visually distinguish child heroes from parent sessions.
-    if (isSubagent) {
-      this.subagentText = addCrispText(scene, x, y + this.subagentOffsetY, 'subagent', {
-        fontSize: '9px',
-        color: '#9AA4B0',
-        fontFamily: 'monospace',
-        fontStyle: 'italic',
-        stroke: '#000000',
-        strokeThickness: 2,
-      }).setOrigin(0.5);
-    }
-
-    // Source badge is created lazily by setSourceBadgeVisible(true) — shown
-    // only when the UI is in mixed-provider mode.
-
-    // Activity label below hero
+    // Activity label is the only text rendered on the sprite — one label per
+    // hero keeps the canvas readable when 5–10 characters are visible at once.
+    // Name, model, source, detail and task all live in the Party Bar / Detail Panel.
     this.activityText = addCrispText(scene, x, y + this.activityOffsetY, 'idle', {
-      fontSize: '12px',
-      color: ACTIVITY_COLOR.idle,
-      fontFamily: 'monospace',
-      stroke: '#000000',
-      strokeThickness: 2,
-    }).setOrigin(0.5);
-
-    // Detail label (file/command) below activity
-    this.detailText = addCrispText(scene, x, y + this.detailOffsetY, '', {
       fontSize: '11px',
-      color: '#AABBCC',
-      fontFamily: 'monospace',
-      stroke: '#000000',
-      strokeThickness: 2,
-    }).setOrigin(0.5);
-
-    // Task label (current user prompt) below detail
-    this.taskText = addCrispText(scene, x, y + this.taskOffsetY, '', {
-      fontSize: '10px',
-      color: '#9FB7D4',
-      fontFamily: 'monospace',
-      fontStyle: 'italic',
-      stroke: '#000000',
-      strokeThickness: 2,
+      color: ACTIVITY_COLOR.idle,
+      fontFamily: "'Fira Code', monospace",
+      backgroundColor: 'rgba(0,0,0,0.65)',
+      padding: { x: 4, y: 2 },
     }).setOrigin(0.5);
 
     // Set initial Y-based depth
@@ -461,7 +392,7 @@ export class HeroSprite {
         {
           fontSize: '9px',
           color: SOURCE_BADGE_COLOR[this.source],
-          fontFamily: 'monospace',
+          fontFamily: "'Fira Code', monospace",
           stroke: '#000000',
           strokeThickness: 2,
         },
@@ -525,7 +456,7 @@ export class HeroSprite {
         {
           fontSize: '11px',
           color: badge.color,
-          fontFamily: 'monospace',
+          fontFamily: "'Fira Code', monospace",
           fontStyle: 'bold',
           stroke: '#000000',
           strokeThickness: 2,

--- a/client/src/game/entities/hero-scale.test.ts
+++ b/client/src/game/entities/hero-scale.test.ts
@@ -1,0 +1,28 @@
+import { describe, test, expect } from 'bun:test';
+import { computeSpriteScale, SUBAGENT_SCALE_FACTOR } from './hero-scale';
+
+describe('computeSpriteScale', () => {
+  test('main session keeps base scale', () => {
+    expect(computeSpriteScale(1.0, false)).toBe(1.0);
+    expect(computeSpriteScale(2.0, false)).toBe(2.0);
+  });
+
+  test('sub-agent shrinks to SUBAGENT_SCALE_FACTOR × base', () => {
+    expect(computeSpriteScale(1.0, true)).toBeCloseTo(SUBAGENT_SCALE_FACTOR);
+    expect(computeSpriteScale(2.0, true)).toBeCloseTo(2.0 * SUBAGENT_SCALE_FACTOR);
+  });
+
+  test('SUBAGENT_SCALE_FACTOR is between 0 and 1 (companion, not invisible)', () => {
+    expect(SUBAGENT_SCALE_FACTOR).toBeGreaterThan(0);
+    expect(SUBAGENT_SCALE_FACTOR).toBeLessThan(1);
+  });
+
+  test('scale composes — runtime resize via setHeroScale preserves factor', () => {
+    const isSubagent = true;
+    const baseScales = [0.5, 1.0, 1.5, 3.0];
+    for (const base of baseScales) {
+      const effective = computeSpriteScale(base, isSubagent);
+      expect(effective).toBeCloseTo(base * SUBAGENT_SCALE_FACTOR);
+    }
+  });
+});

--- a/client/src/game/entities/hero-scale.ts
+++ b/client/src/game/entities/hero-scale.ts
@@ -1,0 +1,20 @@
+/**
+ * Visual scale rules for hero sprites. Pure functions — no Phaser dependency
+ * so unit tests can pin the visual contract without spinning up a scene.
+ */
+
+/**
+ * Multiplicative scale applied to a sub-agent sprite relative to a regular
+ * hero. 0.7 is small enough to read as "companion / helper" without making
+ * the sprite illegible.
+ */
+export const SUBAGENT_SCALE_FACTOR = 0.7;
+
+/**
+ * Effective sprite scale for a hero, given the theme's base hero scale and
+ * whether the hero is a sub-agent. Main session: returns `baseScale`.
+ * Sub-agent: returns `baseScale * SUBAGENT_SCALE_FACTOR`.
+ */
+export function computeSpriteScale(baseScale: number, isSubagent: boolean): number {
+  return isSubagent ? baseScale * SUBAGENT_SCALE_FACTOR : baseScale;
+}

--- a/client/src/game/scenes/BootScene.ts
+++ b/client/src/game/scenes/BootScene.ts
@@ -36,7 +36,9 @@ export class BootScene extends Phaser.Scene {
     // key AND src lets the reader pair a 30%-stuck moment with the exact
     // path that landed last (the stuck file is in flight, not this one).
     this.load.on(Phaser.Loader.Events.FILE_COMPLETE, (key: string, type: string, _data: unknown) => {
-      const file = this.load.list?.entries?.find?.((f: Phaser.Loader.File) => f.key === key);
+      const file = this.load.list
+        ? Array.from(this.load.list.values()).find((f: Phaser.Loader.File) => f.key === key)
+        : undefined;
       const src = file?.src ?? '?';
       console.log(`[BOOT] filecomplete type=${type} key=${key} src=${src}`);
     });

--- a/client/src/game/scenes/BootScene.ts
+++ b/client/src/game/scenes/BootScene.ts
@@ -139,7 +139,7 @@ export class BootScene extends Phaser.Scene {
       this.statusText = addCrispText(this, cx, statusY, headline, {
         fontSize: '16px',
         color: '#f0d89a',
-        fontFamily: 'monospace',
+        fontFamily: "'Fira Code', monospace",
         align: 'center',
         wordWrap: { width: Math.min(this.scale.width * 0.8, 640) },
       }).setOrigin(0.5);
@@ -153,7 +153,7 @@ export class BootScene extends Phaser.Scene {
       const summary = addCrispText(this, cx, statusY + 28, summaryLines, {
         fontSize: '13px',
         color: '#e8c880',
-        fontFamily: 'monospace',
+        fontFamily: "'Fira Code', monospace",
         align: 'left',
       }).setOrigin(0.5, 0);
 
@@ -169,7 +169,7 @@ export class BootScene extends Phaser.Scene {
       const sample = addCrispText(this, cx, summary.y + summary.displayHeight + 16, sampleLines, {
         fontSize: '11px',
         color: '#8ea0b4',
-        fontFamily: 'monospace',
+        fontFamily: "'Fira Code', monospace",
         align: 'left',
         wordWrap: { width: Math.min(this.scale.width * 0.9, 780) },
       }).setOrigin(0.5, 0);
@@ -180,7 +180,7 @@ export class BootScene extends Phaser.Scene {
       const hint = addCrispText(this, cx, sample.y + sample.displayHeight + 20, hintText, {
         fontSize: '12px',
         color: '#aabbcc',
-        fontFamily: 'monospace',
+        fontFamily: "'Fira Code', monospace",
         align: 'center',
         wordWrap: { width: Math.min(this.scale.width * 0.9, 720) },
       }).setOrigin(0.5, 0);
@@ -188,7 +188,7 @@ export class BootScene extends Phaser.Scene {
       const primary = addCrispText(this, cx, hint.y + hint.displayHeight + 24, '↻  Reload page', {
           fontSize: '16px',
           color: '#1a1a2e',
-          fontFamily: 'monospace',
+          fontFamily: "'Fira Code', monospace",
           backgroundColor: '#c4a35a',
           padding: { x: 18, y: 10 },
         })
@@ -203,7 +203,7 @@ export class BootScene extends Phaser.Scene {
     this.statusText = addCrispText(this, cx, statusY, 'Connecting to server...', {
       fontSize: '18px',
       color: '#888888',
-      fontFamily: 'monospace',
+      fontFamily: "'Fira Code', monospace",
     }).setOrigin(0.5);
 
     this.onConnected = () => {

--- a/client/src/game/scenes/BootScene.ts
+++ b/client/src/game/scenes/BootScene.ts
@@ -18,8 +18,43 @@ export class BootScene extends Phaser.Scene {
   }
 
   preload(): void {
+    // Diagnostic logging for issue #13 — preload stuck at ~30%. These three
+    // listeners pin down which file ID was the last to land and at what
+    // progress fraction. Empirically reducing `maxParallelDownloads` makes
+    // things WORSE (drops to 0% stuck), so this PR ships diagnostics only
+    // and the real fix is tracked as the next strand.
     this.load.on(Phaser.Loader.Events.FILE_LOAD_ERROR, (file: Phaser.Loader.File) => {
+      console.warn(`[BOOT] FILE_LOAD_ERROR src=${file.src} key=${file.key} type=${file.type}`);
       this.missingAssets.push(file.src);
+    });
+    this.load.on(Phaser.Loader.Events.COMPLETE, () => {
+      console.log(
+        `[BOOT] preload COMPLETE totalToLoad=${this.load.totalToLoad} totalComplete=${this.load.totalComplete} totalFailed=${this.load.totalFailed}`,
+      );
+    });
+    // FILE_COMPLETE fires when an individual asset finishes. Logging both
+    // key AND src lets the reader pair a 30%-stuck moment with the exact
+    // path that landed last (the stuck file is in flight, not this one).
+    this.load.on(Phaser.Loader.Events.FILE_COMPLETE, (key: string, type: string, _data: unknown) => {
+      const file = this.load.list?.entries?.find?.((f: Phaser.Loader.File) => f.key === key);
+      const src = file?.src ?? '?';
+      console.log(`[BOOT] filecomplete type=${type} key=${key} src=${src}`);
+    });
+    // Log on either a pct bucket change OR a totalComplete tick. The bucket
+    // alone hides progress within a 10% range; tracking totalComplete makes
+    // a partial-load stall (e.g. queue=60, complete frozen at 18) obvious.
+    let lastReportedPct = -1;
+    let lastReportedComplete = -1;
+    this.load.on(Phaser.Loader.Events.PROGRESS, (p: number) => {
+      const pct = Math.floor(p * 10) * 10;
+      const totalComplete = this.load.totalComplete;
+      if (pct !== lastReportedPct || totalComplete !== lastReportedComplete) {
+        lastReportedPct = pct;
+        lastReportedComplete = totalComplete;
+        console.log(
+          `[BOOT] preload progress ${pct}% (totalToLoad=${this.load.totalToLoad}, totalComplete=${totalComplete}, totalFailed=${this.load.totalFailed})`,
+        );
+      }
     });
 
     // Logo shown on the loading screen + reused by the React TopBar

--- a/client/src/game/scenes/VillageScene.ts
+++ b/client/src/game/scenes/VillageScene.ts
@@ -879,7 +879,17 @@ export class VillageScene extends Phaser.Scene {
       }
     }
 
-    for (const agent of visible) {
+    // Process parent heroes before sub-agents so that `canAttachSubagent`
+    // sees the parent in `this.heroes` when the child is spawned.  A single
+    // sort pass is O(n log n) and avoids a two-pass loop for the common case
+    // where parents and children arrive in the same snapshot.
+    const orderedVisible = [...visible].sort((a, b) => {
+      const aIsChild = a.isSubagent ? 1 : 0;
+      const bIsChild = b.isSubagent ? 1 : 0;
+      return aIsChild - bIsChild;
+    });
+
+    for (const agent of orderedVisible) {
       const existing = this.heroes.get(agent.id);
       const buildingDef = getBuildingForActivity(agent.currentActivity);
       const attachable = this.canAttachSubagent(agent);

--- a/client/src/game/scenes/VillageScene.ts
+++ b/client/src/game/scenes/VillageScene.ts
@@ -13,6 +13,8 @@ import type { AssetManifest, MapConfig, BuildingPosition, NpcPlacement } from '.
 import { SERVER_URL as API_BASE } from '../../config';
 import { getActiveTheme, rebaseSavedScale } from '../themes/registry';
 import { computeShowSourceBadge } from '../../presentation/agentPresentation';
+import { TILE_SIZE } from '../../editor/types/map';
+import { computeChildOffset } from './subagent-layout';
 
 /** Set `cam.zoom` to `newZoom` while keeping the world point currently
  * under screen coordinates (sx, sy) pinned to the same screen spot.
@@ -46,6 +48,17 @@ export class VillageScene extends Phaser.Scene {
 
   /** Tracks which building each hero is currently assigned to. */
   private heroBuildingMap = new Map<string, string>();
+
+  /**
+   * Parent → set of attached sub-agent ids. Attached sub-agents bypass
+   * `buildingSlots` entirely and follow their parent's position frame to
+   * frame. Orphan sub-agents (parent gone or never seen) fall back to
+   * regular slot assignment and are absent from this map.
+   */
+  private parentChildren = new Map<string, Set<string>>();
+
+  /** Reverse lookup: attached child id → parent id. */
+  private subagentParents = new Map<string, string>();
 
   /** Atmospheric effects */
   private nightOverlay: Phaser.GameObjects.Graphics | null = null;
@@ -381,6 +394,8 @@ export class VillageScene extends Phaser.Scene {
       this.buildings = [];
       this.buildingSlots.clear();
       this.heroBuildingMap.clear();
+      this.parentChildren.clear();
+      this.subagentParents.clear();
       for (const npc of this.editorNpcs) npc.destroy();
       this.editorNpcs = [];
     };
@@ -572,6 +587,65 @@ export class VillageScene extends Phaser.Scene {
   // Slot management
   // ---------------------------------------------------------------------------
 
+  /**
+   * Is this agent eligible to render as an attached sub-agent (companion of
+   * a live parent)? Returns true only when a parent hero is currently on
+   * screen — orphan sub-agents fall through to regular slot layout.
+   */
+  private canAttachSubagent(agent: AgentState): boolean {
+    if (!agent.isSubagent) return false;
+    if (agent.parentSessionId === undefined) return false;
+    return this.heroes.has(agent.parentSessionId);
+  }
+
+  private attachSubagent(parentId: string, childId: string): void {
+    this.subagentParents.set(childId, parentId);
+    let siblings = this.parentChildren.get(parentId);
+    if (siblings === undefined) {
+      siblings = new Set();
+      this.parentChildren.set(parentId, siblings);
+    }
+    siblings.add(childId);
+  }
+
+  private detachSubagent(childId: string): void {
+    const parentId = this.subagentParents.get(childId);
+    if (parentId === undefined) return;
+    this.subagentParents.delete(childId);
+    const siblings = this.parentChildren.get(parentId);
+    if (siblings === undefined) return;
+    siblings.delete(childId);
+    if (siblings.size === 0) {
+      this.parentChildren.delete(parentId);
+    }
+  }
+
+  /**
+   * Each frame, anchor every attached sub-agent to its parent's current
+   * position plus a deterministic stagger offset. Sub-agents bypass the
+   * tween-driven road network, so this is what actually makes them follow.
+   */
+  override update(): void {
+    if (this.parentChildren.size === 0) return;
+    for (const [parentId, siblings] of this.parentChildren) {
+      const parentHero = this.heroes.get(parentId);
+      if (parentHero === undefined) continue;
+      const sortedSiblings = [...siblings].sort();
+      for (let i = 0; i < sortedSiblings.length; i++) {
+        const childId = sortedSiblings[i];
+        if (childId === undefined) continue;
+        const child = this.heroes.get(childId);
+        if (child === undefined) continue;
+        const offset = computeChildOffset(
+          { x: parentHero.x, y: parentHero.y },
+          i,
+          TILE_SIZE,
+        );
+        child.teleportTo(offset.x, offset.y);
+      }
+    }
+  }
+
   private addToSlot(buildingId: string, heroId: string): void {
     let slots = this.buildingSlots.get(buildingId);
     if (slots === undefined) {
@@ -652,9 +726,35 @@ export class VillageScene extends Phaser.Scene {
     // against the unfiltered `agents` snapshot.
     const showSourceBadge = computeShowSourceBadge(agents);
 
+    // Track which buildings need repositioning. Declared up here because both
+    // the removal pass (parent leaves → children orphan into slots) and the
+    // visible-iteration pass below need to flag dirty buildings.
+    const buildingsToReposition = new Set<string>();
+
     // Remove heroes no longer visible
     for (const [id, hero] of this.heroes) {
       if (!visible.some((a) => a.id === id)) {
+        // If a parent goes away, promote each attached child to orphan so it
+        // re-enters slot-based layout instead of vanishing along with the parent.
+        const orphanedChildren = this.parentChildren.get(id);
+        if (orphanedChildren !== undefined) {
+          for (const childId of orphanedChildren) {
+            this.subagentParents.delete(childId);
+            const childHero = this.heroes.get(childId);
+            const childAgent = visible.find((a) => a.id === childId);
+            if (childHero !== undefined && childAgent !== undefined) {
+              const childBuildingDef = getBuildingForActivity(childAgent.currentActivity);
+              this.addToSlot(childBuildingDef.id, childId);
+              buildingsToReposition.add(childBuildingDef.id);
+            }
+          }
+          this.parentChildren.delete(id);
+        }
+
+        // If the leaving hero was itself an attached sub-agent, detach cleanly
+        // and re-layout the remaining siblings so the deterministic order tightens.
+        this.detachSubagent(id);
+
         const oldBuilding = this.removeFromSlot(id);
         hero.destroy();
         this.heroes.delete(id);
@@ -664,15 +764,14 @@ export class VillageScene extends Phaser.Scene {
       }
     }
 
-    // Track which buildings need repositioning
-    const buildingsToReposition = new Set<string>();
-
     for (const agent of visible) {
       const existing = this.heroes.get(agent.id);
       const buildingDef = getBuildingForActivity(agent.currentActivity);
+      const attachable = this.canAttachSubagent(agent);
 
       if (existing === undefined) {
-        // New hero: spawn at configured spawn point then assign to building
+        // New hero: spawn at configured spawn point then either follow the
+        // parent (attached sub-agent) or take a regular building slot.
         const hero = new HeroSprite(
           this,
           agent.id,
@@ -681,7 +780,7 @@ export class VillageScene extends Phaser.Scene {
           agent.heroColor,
           this.heroSpawn.x,
           this.heroSpawn.y,
-          agent.id.startsWith('agent-'),
+          agent.isSubagent,
           agent.source,
         );
         hero.setHeroScale(this.heroScale);
@@ -695,8 +794,13 @@ export class VillageScene extends Phaser.Scene {
         hero.setInteractiveForSelection(() => {
           eventBridge.emit('hero:clicked', agent.id);
         });
-        this.addToSlot(buildingDef.id, agent.id);
-        buildingsToReposition.add(buildingDef.id);
+
+        if (attachable) {
+          this.attachSubagent(agent.parentSessionId as string, agent.id);
+        } else {
+          this.addToSlot(buildingDef.id, agent.id);
+          buildingsToReposition.add(buildingDef.id);
+        }
       } else {
         // Always update detail text (file/command changes even without activity change)
         existing.updateName(agent.name);
@@ -706,20 +810,38 @@ export class VillageScene extends Phaser.Scene {
         existing.setErrorTimestamp(agent.lastErrorAt);
         existing.setModel(agent.model);
 
-        const currentBuildingId = this.heroBuildingMap.get(agent.id);
-
-        if (currentBuildingId !== buildingDef.id) {
-          // Hero changed building — update activity before repositioning
+        const wasAttached = this.subagentParents.has(agent.id);
+        if (wasAttached && !attachable) {
+          // Orphaned mid-life — leave the parent group and fall back to slot.
+          this.detachSubagent(agent.id);
           existing.setActivity(agent.currentActivity);
-          const oldBuilding = this.removeFromSlot(agent.id);
           this.addToSlot(buildingDef.id, agent.id);
-
-          if (oldBuilding !== undefined) {
-            buildingsToReposition.add(oldBuilding);
-          }
           buildingsToReposition.add(buildingDef.id);
+        } else if (!wasAttached && attachable && this.heroBuildingMap.has(agent.id)) {
+          // Newly attachable (parent appeared) — vacate slot and follow parent.
+          const oldBuilding = this.removeFromSlot(agent.id);
+          if (oldBuilding !== undefined) buildingsToReposition.add(oldBuilding);
+          this.attachSubagent(agent.parentSessionId as string, agent.id);
+        } else if (!wasAttached) {
+          const currentBuildingId = this.heroBuildingMap.get(agent.id);
+
+          if (currentBuildingId !== buildingDef.id) {
+            // Hero changed building — update activity before repositioning
+            existing.setActivity(agent.currentActivity);
+            const oldBuilding = this.removeFromSlot(agent.id);
+            this.addToSlot(buildingDef.id, agent.id);
+
+            if (oldBuilding !== undefined) {
+              buildingsToReposition.add(oldBuilding);
+            }
+            buildingsToReposition.add(buildingDef.id);
+          } else if (existing.currentActivity !== agent.currentActivity) {
+            // Same building, different activity — update label
+            existing.setActivity(agent.currentActivity);
+          }
         } else if (existing.currentActivity !== agent.currentActivity) {
-          // Same building, different activity — update label
+          // Attached sub-agent — keep activity label up to date; layout is
+          // driven by the parent's position each frame.
           existing.setActivity(agent.currentActivity);
         }
       }

--- a/client/src/game/scenes/VillageScene.ts
+++ b/client/src/game/scenes/VillageScene.ts
@@ -13,6 +13,16 @@ import type { AssetManifest, MapConfig, BuildingPosition, NpcPlacement } from '.
 import { SERVER_URL as API_BASE } from '../../config';
 import { getActiveTheme, rebaseSavedScale } from '../themes/registry';
 import { computeShowSourceBadge } from '../../presentation/agentPresentation';
+
+// Mirror of PartyBar's STATUS_ORDER. Both surfaces sort by the same key so the
+// number rendered above each hero in the village matches its row in the panel.
+const STATUS_ORDER: Record<AgentState['status'], number> = {
+  active: 0,
+  waiting: 1,
+  idle: 2,
+  error: 3,
+  completed: 4,
+};
 import { TILE_SIZE } from '../../editor/types/map';
 import { computeChildOffset } from './subagent-layout';
 
@@ -852,6 +862,17 @@ export class VillageScene extends Phaser.Scene {
     for (const hero of this.heroes.values()) {
       hero.setSourceBadgeVisible(showSourceBadge);
     }
+
+    // Assign party index (1-based) using the same status-ordered sort PartyBar
+    // applies — that's what ties the marker above the sprite to the row in the
+    // side panel. Hidden heroes (subagents whose parent isn't here yet) still
+    // get a number but it's safe to skip if `setIndex` is no-op on them.
+    const indexed = [...visible].sort(
+      (a, b) => STATUS_ORDER[a.status] - STATUS_ORDER[b.status],
+    );
+    indexed.forEach((agent, i) => {
+      this.heroes.get(agent.id)?.setIndex(i + 1);
+    });
 
     for (const buildingId of buildingsToReposition) {
       this.repositionBuilding(buildingId);

--- a/client/src/game/scenes/VillageScene.ts
+++ b/client/src/game/scenes/VillageScene.ts
@@ -25,6 +25,14 @@ const STATUS_ORDER: Record<AgentState['status'], number> = {
 };
 import { TILE_SIZE } from '../../editor/types/map';
 import { computeChildOffset } from './subagent-layout';
+import {
+  buildConnectorSegments,
+  CONNECTOR_COLOR,
+  CONNECTOR_ALPHA,
+  CONNECTOR_LINE_WIDTH,
+  CONNECTOR_DASH_LENGTH,
+  CONNECTOR_GAP_LENGTH,
+} from './subagent-connector';
 
 /** Set `cam.zoom` to `newZoom` while keeping the world point currently
  * under screen coordinates (sx, sy) pinned to the same screen spot.
@@ -69,6 +77,13 @@ export class VillageScene extends Phaser.Scene {
 
   /** Reverse lookup: attached child id → parent id. */
   private subagentParents = new Map<string, string>();
+
+  /**
+   * Reusable Graphics object for drawing the dashed connector lines between
+   * parent heroes and their attached sub-agents. Cleared and redrawn each
+   * frame in `update()` so it always reflects current hero positions.
+   */
+  private subagentConnectorGraphics: Phaser.GameObjects.Graphics | null = null;
 
   /** Atmospheric effects */
   private nightOverlay: Phaser.GameObjects.Graphics | null = null;
@@ -210,6 +225,13 @@ export class VillageScene extends Phaser.Scene {
         pinchStartDist = 0;
       }
     });
+
+    // --- Sub-agent connector lines ---
+    // A single reusable Graphics layer cleared and redrawn each frame in update().
+    // Depth sits just below sprites (footY + 0.3) so connectors appear as
+    // ground-level guides without obscuring hero labels.
+    this.subagentConnectorGraphics = this.add.graphics();
+    this.subagentConnectorGraphics.setDepth(0.3);
 
     // --- Night overlay ---
     this.nightOverlay = this.add.graphics();
@@ -646,7 +668,19 @@ export class VillageScene extends Phaser.Scene {
    * tween-driven road network, so this is what actually makes them follow.
    */
   override update(): void {
+    // Always clear connectors — even when parentChildren is empty so leftover
+    // lines from a previous frame disappear when the last sub-agent detaches.
+    this.subagentConnectorGraphics?.clear();
+
     if (this.parentChildren.size === 0) return;
+
+    const connectorPairs: Array<{
+      parentX: number;
+      parentY: number;
+      childX: number;
+      childY: number;
+    }> = [];
+
     for (const [parentId, siblings] of this.parentChildren) {
       const parentHero = this.heroes.get(parentId);
       if (parentHero === undefined) continue;
@@ -662,6 +696,67 @@ export class VillageScene extends Phaser.Scene {
           TILE_SIZE,
         );
         child.teleportTo(offset.x, offset.y);
+        connectorPairs.push({
+          parentX: parentHero.x,
+          parentY: parentHero.y,
+          childX: offset.x,
+          childY: offset.y,
+        });
+      }
+    }
+
+    this.drawSubagentConnectors(connectorPairs);
+  }
+
+  /**
+   * Draw dashed lines connecting each parent hero to its attached sub-agents.
+   *
+   * Uses `buildConnectorSegments` (pure, testable) for geometry and draws
+   * a dash-gap pattern manually since Phaser's Graphics API does not expose
+   * a native `setLineDash` equivalent. The result is a subtle dotted line
+   * that reads as a "belongs to" relation without overpowering the sprites.
+   */
+  private drawSubagentConnectors(
+    pairs: ReadonlyArray<{
+      parentX: number;
+      parentY: number;
+      childX: number;
+      childY: number;
+    }>,
+  ): void {
+    const graphics = this.subagentConnectorGraphics;
+    if (graphics === null || pairs.length === 0) return;
+
+    const segments = buildConnectorSegments(pairs);
+    graphics.lineStyle(CONNECTOR_LINE_WIDTH, CONNECTOR_COLOR, CONNECTOR_ALPHA);
+
+    for (const segment of segments) {
+      if (segment.length < 1) continue;
+
+      const dx = (segment.x2 - segment.x1) / segment.length;
+      const dy = (segment.y2 - segment.y1) / segment.length;
+      let traveled = 0;
+      let drawing = true;
+
+      while (traveled < segment.length) {
+        const segmentEnd = Math.min(
+          traveled + (drawing ? CONNECTOR_DASH_LENGTH : CONNECTOR_GAP_LENGTH),
+          segment.length,
+        );
+        if (drawing) {
+          graphics.beginPath();
+          graphics.moveTo(
+            segment.x1 + dx * traveled,
+            segment.y1 + dy * traveled,
+          );
+          graphics.lineTo(
+            segment.x1 + dx * segmentEnd,
+            segment.y1 + dy * segmentEnd,
+          );
+          graphics.strokePath();
+        }
+        traveled = segmentEnd;
+        drawing = !drawing;
       }
     }
   }

--- a/client/src/game/scenes/VillageScene.ts
+++ b/client/src/game/scenes/VillageScene.ts
@@ -699,6 +699,7 @@ export class VillageScene extends Phaser.Scene {
         buildingsToReposition.add(buildingDef.id);
       } else {
         // Always update detail text (file/command changes even without activity change)
+        existing.updateName(agent.name);
         existing.updateDetail(agent.currentFile, agent.currentCommand);
         existing.updateTask(agent.currentTask);
         existing.setStatus(agent.status);

--- a/client/src/game/scenes/VillageScene.ts
+++ b/client/src/game/scenes/VillageScene.ts
@@ -111,6 +111,16 @@ export class VillageScene extends Phaser.Scene {
     // this colour is only visible past the map edges or during zoom-out.
     this.cameras.main.setBackgroundColor('#000000');
 
+    // Brightness boost — a subtle additive white overlay lifts the dark forest
+    // tones so the village reads clearly as a PiP overlay in YouTube Shorts.
+    const brightnessOverlay = this.add.rectangle(
+      WORLD_WIDTH / 2, WORLD_HEIGHT / 2,
+      WORLD_WIDTH, WORLD_HEIGHT,
+      0xFFFFFF, 0.06,
+    );
+    brightnessOverlay.setBlendMode(Phaser.BlendModes.ADD);
+    brightnessOverlay.setDepth(0.01);
+
     // Signal React that the village is up so it can reveal the HTML overlays
     // (TopBar, PartyBar, etc.) that should stay hidden during the BootScene.
     eventBridge.emit('village:ready');

--- a/client/src/game/scenes/VillageScene.ts
+++ b/client/src/game/scenes/VillageScene.ts
@@ -12,6 +12,7 @@ import type { AgentState } from '../../types/agent';
 import type { AssetManifest, MapConfig, BuildingPosition, NpcPlacement } from '../../editor/types/map';
 import { SERVER_URL as API_BASE } from '../../config';
 import { getActiveTheme, rebaseSavedScale } from '../themes/registry';
+import { computeShowSourceBadge } from '../../presentation/agentPresentation';
 
 /** Set `cam.zoom` to `newZoom` while keeping the world point currently
  * under screen coordinates (sx, sy) pinned to the same screen spot.
@@ -634,21 +635,22 @@ export class VillageScene extends Phaser.Scene {
 
     const now = Date.now();
 
-    // Show active + idle-recent (< 2h), hide completed/error and idle > 2h
+    // App-level presentation projection already excludes `waiting` / `error`,
+    // and gates `completed` behind the TopBar toggle. The scene applies two
+    // additional local policies: hide `error` defensively, and drop heroes
+    // that have been idle for longer than IDLE_HIDE_THRESHOLD_MS so the
+    // village doesn't grow unbounded over a long-lived session.
     const visible = agents.filter((a) => {
-      if (a.status === 'completed' || a.status === 'error') return false;
+      if (a.status === 'error') return false;
       if (a.status === 'idle' && now - a.lastEvent > IDLE_HIDE_THRESHOLD_MS) return false;
       return true;
     });
 
     // Mixed-provider mode: show source badges only when both Claude and Codex
-    // have a LIVE hero. Completed/error sessions don't count, so the badge
-    // disappears the moment the last non-dormant Codex hero finishes. Mirrors
-    // the flag computed in App.tsx — keep these two in sync.
-    const liveAgents = agents.filter((a) => a.status !== 'completed' && a.status !== 'error');
-    const hasClaude = liveAgents.some((a) => a.source === 'claude');
-    const hasCodex = liveAgents.some((a) => a.source === 'codex');
-    const showSourceBadge = hasClaude && hasCodex;
+    // have a LIVE hero. Computed by the shared `computeShowSourceBadge` helper
+    // so this stays in lockstep with App.tsx — both call the same function
+    // against the unfiltered `agents` snapshot.
+    const showSourceBadge = computeShowSourceBadge(agents);
 
     // Remove heroes no longer visible
     for (const [id, hero] of this.heroes) {

--- a/client/src/game/scenes/subagent-connector.test.ts
+++ b/client/src/game/scenes/subagent-connector.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for sub-agent connector line visual parameters.
+ *
+ * Pure functions (no Phaser dependency) so tests run fast with bun:test.
+ */
+import { describe, test, expect } from 'bun:test';
+import {
+  buildConnectorSegments,
+  CONNECTOR_COLOR,
+  CONNECTOR_ALPHA,
+  CONNECTOR_LINE_WIDTH,
+  CONNECTOR_DASH_LENGTH,
+  CONNECTOR_GAP_LENGTH,
+} from './subagent-connector';
+
+describe('buildConnectorSegments', () => {
+  test('returns empty array when no parent-child pairs', () => {
+    const result = buildConnectorSegments([]);
+    expect(result).toEqual([]);
+  });
+
+  test('single pair produces two endpoints matching input positions', () => {
+    const pairs = [{ parentX: 100, parentY: 200, childX: 160, childY: 200 }];
+    const [segment] = buildConnectorSegments(pairs);
+    expect(segment).toBeDefined();
+    expect(segment!.x1).toBe(100);
+    expect(segment!.y1).toBe(200);
+    expect(segment!.x2).toBe(160);
+    expect(segment!.y2).toBe(200);
+  });
+
+  test('multiple pairs produce one segment each', () => {
+    const pairs = [
+      { parentX: 50, parentY: 80, childX: 90, childY: 80 },
+      { parentX: 200, parentY: 300, childX: 240, childY: 300 },
+    ];
+    const result = buildConnectorSegments(pairs);
+    expect(result).toHaveLength(2);
+  });
+
+  test('segment length is correct Euclidean distance', () => {
+    const pairs = [{ parentX: 0, parentY: 0, childX: 3, childY: 4 }];
+    const [segment] = buildConnectorSegments(pairs);
+    expect(segment!.length).toBeCloseTo(5);
+  });
+
+  test('zero-distance pair returns segment with length 0', () => {
+    const pairs = [{ parentX: 100, parentY: 100, childX: 100, childY: 100 }];
+    const [segment] = buildConnectorSegments(pairs);
+    expect(segment!.length).toBeCloseTo(0);
+  });
+
+  test('deterministic — same inputs produce same output', () => {
+    const pairs = [{ parentX: 10, parentY: 20, childX: 50, childY: 80 }];
+    const a = buildConnectorSegments(pairs);
+    const b = buildConnectorSegments(pairs);
+    expect(a).toEqual(b);
+  });
+});
+
+describe('CONNECTOR_COLOR constant', () => {
+  test('is a positive integer (Phaser hex color)', () => {
+    expect(typeof CONNECTOR_COLOR).toBe('number');
+    expect(CONNECTOR_COLOR).toBeGreaterThan(0);
+  });
+});
+
+describe('CONNECTOR_ALPHA constant', () => {
+  test('is between 0 and 1 (visible but not fully opaque)', () => {
+    expect(CONNECTOR_ALPHA).toBeGreaterThan(0);
+    expect(CONNECTOR_ALPHA).toBeLessThanOrEqual(1);
+    // Should not be full opacity — connector should be subtle
+    expect(CONNECTOR_ALPHA).toBeLessThan(1);
+  });
+});
+
+describe('CONNECTOR_LINE_WIDTH constant', () => {
+  test('is a positive number (visible line)', () => {
+    expect(CONNECTOR_LINE_WIDTH).toBeGreaterThan(0);
+    // Should stay thin (1-3 px) to not overpower the sprites
+    expect(CONNECTOR_LINE_WIDTH).toBeLessThanOrEqual(3);
+  });
+});
+
+describe('CONNECTOR_DASH_LENGTH and CONNECTOR_GAP_LENGTH constants', () => {
+  test('dash and gap are positive numbers', () => {
+    expect(CONNECTOR_DASH_LENGTH).toBeGreaterThan(0);
+    expect(CONNECTOR_GAP_LENGTH).toBeGreaterThan(0);
+  });
+
+  test('dash is at least as long as gap (dash-dominant pattern)', () => {
+    expect(CONNECTOR_DASH_LENGTH).toBeGreaterThanOrEqual(CONNECTOR_GAP_LENGTH);
+  });
+});

--- a/client/src/game/scenes/subagent-connector.ts
+++ b/client/src/game/scenes/subagent-connector.ts
@@ -1,0 +1,57 @@
+/**
+ * Pure helpers for rendering the connector line between a parent hero and its
+ * attached sub-agents.
+ *
+ * Kept Phaser-free so unit tests can verify the geometry without a live scene.
+ * VillageScene calls `buildConnectorSegments` each frame then draws the result
+ * with a Phaser Graphics object.
+ */
+
+/** Phaser hex color for the connector dashed line (soft cyan-purple, fantasy feel). */
+export const CONNECTOR_COLOR = 0x9b72cf;
+
+/** Opacity of the connector line — subtle enough not to overpower sprites. */
+export const CONNECTOR_ALPHA = 0.55;
+
+/** Stroke width in pixels. Thin so it reads as a relation hint, not a UI chrome. */
+export const CONNECTOR_LINE_WIDTH = 1.5;
+
+/** Length of each drawn dash segment in pixels. */
+export const CONNECTOR_DASH_LENGTH = 6;
+
+/** Length of the gap between dash segments in pixels. */
+export const CONNECTOR_GAP_LENGTH = 4;
+
+export interface ConnectorPair {
+  parentX: number;
+  parentY: number;
+  childX: number;
+  childY: number;
+}
+
+export interface ConnectorSegment {
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  /** Euclidean distance between endpoints (pre-computed for dash iteration). */
+  length: number;
+}
+
+/**
+ * Convert an array of parent-child world-position pairs into connector segment
+ * descriptors ready for rendering.
+ *
+ * The caller (VillageScene.update) collects current positions each frame and
+ * passes them here. This function stays pure so it's trivially testable.
+ */
+export function buildConnectorSegments(
+  pairs: readonly ConnectorPair[],
+): ConnectorSegment[] {
+  return pairs.map(({ parentX, parentY, childX, childY }) => {
+    const dx = childX - parentX;
+    const dy = childY - parentY;
+    const length = Math.sqrt(dx * dx + dy * dy);
+    return { x1: parentX, y1: parentY, x2: childX, y2: childY, length };
+  });
+}

--- a/client/src/game/scenes/subagent-layout.test.ts
+++ b/client/src/game/scenes/subagent-layout.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect } from 'bun:test';
+import {
+  CHILD_STAGGER_TILE_OFFSET,
+  FIRST_CHILD_TILE_OFFSET,
+  childIndexOf,
+  computeChildOffset,
+} from './subagent-layout';
+
+describe('computeChildOffset', () => {
+  test('first child sits one offset to the parent right, same Y', () => {
+    const result = computeChildOffset({ x: 100, y: 200 }, 0, 32);
+    expect(result.x).toBeCloseTo(100 + FIRST_CHILD_TILE_OFFSET * 32);
+    expect(result.y).toBe(200);
+  });
+
+  test('second child stays staggered by one tile beyond the first', () => {
+    const result = computeChildOffset({ x: 100, y: 200 }, 1, 32);
+    const expectedGap =
+      FIRST_CHILD_TILE_OFFSET + CHILD_STAGGER_TILE_OFFSET;
+    expect(result.x).toBeCloseTo(100 + expectedGap * 32);
+    expect(result.y).toBe(200);
+  });
+
+  test('third child continues deterministic fan-out', () => {
+    const result = computeChildOffset({ x: 100, y: 200 }, 2, 32);
+    const expectedGap =
+      FIRST_CHILD_TILE_OFFSET + 2 * CHILD_STAGGER_TILE_OFFSET;
+    expect(result.x).toBeCloseTo(100 + expectedGap * 32);
+  });
+
+  test('deterministic — same inputs yield same outputs', () => {
+    const a = computeChildOffset({ x: 50, y: 75 }, 3, 16);
+    const b = computeChildOffset({ x: 50, y: 75 }, 3, 16);
+    expect(a).toEqual(b);
+  });
+
+  test('scales with tile width', () => {
+    const small = computeChildOffset({ x: 0, y: 0 }, 0, 10);
+    const large = computeChildOffset({ x: 0, y: 0 }, 0, 100);
+    expect(large.x).toBeCloseTo(small.x * 10);
+  });
+});
+
+describe('childIndexOf', () => {
+  test('returns lexicographically sorted index', () => {
+    const siblings = ['agent-c', 'agent-a', 'agent-b'];
+    expect(childIndexOf('agent-a', siblings)).toBe(0);
+    expect(childIndexOf('agent-b', siblings)).toBe(1);
+    expect(childIndexOf('agent-c', siblings)).toBe(2);
+  });
+
+  test('stable across input order — adding a sibling keeps existing slots', () => {
+    const before = ['agent-b', 'agent-d'];
+    const after = ['agent-d', 'agent-b', 'agent-a'];
+    expect(childIndexOf('agent-b', before)).toBe(0);
+    expect(childIndexOf('agent-d', before)).toBe(1);
+    // After 'agent-a' joins, 'agent-b' shifts to index 1, 'agent-d' to 2.
+    // 'agent-a' takes the now-leading slot.
+    expect(childIndexOf('agent-a', after)).toBe(0);
+    expect(childIndexOf('agent-b', after)).toBe(1);
+    expect(childIndexOf('agent-d', after)).toBe(2);
+  });
+
+  test('returns -1 when sessionId is not in the sibling list', () => {
+    expect(childIndexOf('agent-z', ['agent-a', 'agent-b'])).toBe(-1);
+  });
+
+  test('input array is not mutated by sorting', () => {
+    const original = ['agent-c', 'agent-a', 'agent-b'];
+    const snapshot = [...original];
+    childIndexOf('agent-a', original);
+    expect(original).toEqual(snapshot);
+  });
+});

--- a/client/src/game/scenes/subagent-layout.ts
+++ b/client/src/game/scenes/subagent-layout.ts
@@ -1,0 +1,58 @@
+/**
+ * Pure helpers for placing sub-agent sprites relative to their parent hero.
+ *
+ * Kept Phaser-free so unit tests can pin the visual contract without a scene.
+ * VillageScene calls these to decide where each attached sub-agent should
+ * render frame to frame.
+ */
+
+/** Horizontal offset (in tile widths) for the *first* attached sub-agent. */
+export const FIRST_CHILD_TILE_OFFSET = 0.7;
+
+/** Incremental tile-width gap between successive sub-agents of the same parent. */
+export const CHILD_STAGGER_TILE_OFFSET = 0.7;
+
+export interface Point {
+  x: number;
+  y: number;
+}
+
+/**
+ * Compute the screen position for an attached sub-agent given the parent
+ * hero's current position, the sub-agent's index among siblings (0-based,
+ * stable sort by sessionId), and the tile width in pixels.
+ *
+ * Layout: sub-agents fan out to the parent's right at evenly spaced
+ * intervals. Index 0 sits one offset to the right, index 1 two offsets,
+ * etc. Y matches the parent so feet stay on the same ground line.
+ *
+ * Deterministic — same inputs always yield the same position, so update
+ * cycles don't jitter the layout.
+ */
+export function computeChildOffset(
+  parentPos: Point,
+  childIndex: number,
+  tileWidth: number,
+): Point {
+  const horizontalGap =
+    FIRST_CHILD_TILE_OFFSET + childIndex * CHILD_STAGGER_TILE_OFFSET;
+  return {
+    x: parentPos.x + horizontalGap * tileWidth,
+    y: parentPos.y,
+  };
+}
+
+/**
+ * Determine the stable child index of `childSessionId` among a parent's
+ * sub-agents. Siblings are sorted lexicographically by session id so that
+ * adding or removing a sibling re-uses existing slots predictably.
+ *
+ * Returns -1 if `childSessionId` is not present in `siblingSessionIds`.
+ */
+export function childIndexOf(
+  childSessionId: string,
+  siblingSessionIds: readonly string[],
+): number {
+  const sorted = [...siblingSessionIds].sort();
+  return sorted.indexOf(childSessionId);
+}

--- a/client/src/game/terrain/TerrainRenderer.ts
+++ b/client/src/game/terrain/TerrainRenderer.ts
@@ -669,7 +669,7 @@ export class TerrainRenderer {
     p.fillStyle(0x6B4E2E, 0.95); p.fillRect(sx - 1.5, sy - 18, 3, 22);
     p.fillStyle(0x8B7A5A, 0.95); p.fillRect(sx - 22, sy - 14, 44, 10);
     p.lineStyle(1, 0x3A2A18, 0.8); p.strokeRect(sx - 22, sy - 14, 44, 10);
-    addCrispText(this.scene, sx, sy - 9, 'Mossvale', { fontSize: '10px', color: '#F5E6C8', fontFamily: 'monospace' }).setOrigin(0.5).setDepth(sy + 0.6);
+    addCrispText(this.scene, sx, sy - 9, 'Mossvale', { fontSize: '10px', color: '#F5E6C8', fontFamily: "'Fira Code', monospace" }).setOrigin(0.5).setDepth(sy + 0.6);
   }
 
   // --- shadows ---------------------------------------------------------
@@ -748,7 +748,7 @@ export class TerrainRenderer {
     g.lineStyle(4, 0x6B4E2E, 0.85); g.beginPath(); g.arc(gx, gy - 20, 44, Math.PI, 0, false); g.strokePath();
     g.fillStyle(0xC4A35A, 0.75); g.fillCircle(gx - 8, gy - 4, 3); g.fillCircle(gx + 8, gy - 4, 3);
     addCrispText(this.scene, gx, gy - 36, 'Village Gate', {
-      fontSize: '14px', color: '#C4A35A', fontFamily: 'monospace', stroke: '#000000', strokeThickness: 2,
+      fontSize: '14px', color: '#C4A35A', fontFamily: "'Cinzel', serif", stroke: '#000000', strokeThickness: 2,
     }).setOrigin(0.5, 1).setDepth(1);
   }
 
@@ -782,7 +782,7 @@ export class TerrainRenderer {
       g.fillStyle(0x6B4E2E, 0.95); g.fillRect(s.x - 1.5, s.y - 18, 3, 22);
       g.fillStyle(0x8B7A5A, 0.95); g.fillRect(s.x - 22, s.y - 14, 44, 10);
       g.lineStyle(1, 0x3A2A18, 0.8); g.strokeRect(s.x - 22, s.y - 14, 44, 10);
-      addCrispText(this.scene, s.x, s.y - 9, s.label, { fontSize: '10px', color: '#F5E6C8', fontFamily: 'monospace' })
+      addCrispText(this.scene, s.x, s.y - 9, s.label, { fontSize: '10px', color: '#F5E6C8', fontFamily: "'Fira Code', monospace" })
         .setOrigin(0.5).setDepth(s.y + 0.6);
     }
   }

--- a/client/src/game/text.ts
+++ b/client/src/game/text.ts
@@ -6,7 +6,7 @@ import * as Phaser from 'phaser';
 // at DPR=1; the *2.5 factor leaves headroom for one or two cmd+ steps before
 // we have to re-render. Recomputed on every DPR change (see watchDpr below).
 function computeTextRes(): number {
-  return Math.max(4, Math.ceil(window.devicePixelRatio * 2.5));
+  return Math.max(2, Math.ceil(window.devicePixelRatio));
 }
 
 let currentTextRes = computeTextRes();

--- a/client/src/game/text.ts
+++ b/client/src/game/text.ts
@@ -41,7 +41,7 @@ export function addCrispText(
   style: Phaser.Types.GameObjects.Text.TextStyle,
 ): Phaser.GameObjects.Text {
   const t = scene.add.text(x, y, text, { resolution: currentTextRes, ...style });
-  const reapplyFilter = () => t.texture.setFilter(Phaser.Textures.FilterMode.NEAREST);
+  const reapplyFilter = () => t.texture.setFilter(Phaser.Textures.FilterMode.LINEAR);
   reapplyFilter();
   const original = t.updateText.bind(t);
   t.updateText = () => {

--- a/client/src/game/text.ts
+++ b/client/src/game/text.ts
@@ -21,16 +21,17 @@ const crispTexts = new Set<Phaser.GameObjects.Text>();
  * Add a Text game object that stays readable under `pixelArt: true`.
  *
  * The game config enables `pixelArt`, which forces NEAREST filtering on
- * every WebGL texture so sprite art stays crisp. Text objects render to
- * an internal canvas and upload it as a texture — with NEAREST that canvas
- * gets visibly aliased whenever the camera zooms or sub-pixel positions
- * the label.
+ * every WebGL texture so sprite art stays crisp. Text textures inherit the
+ * same NEAREST sampling — that's correct for pixel-style fonts (Pixelify
+ * Sans, Cinzel) at scale, because LINEAR sampling would bilinearly smear
+ * the rasterized canvas and read as "blurry" against the painterly tile
+ * background. The wrapped updateText re-applies NEAREST after every
+ * canvasToTexture() re-upload (setText / setColor / setStyle all route
+ * through it and reset the GL min/mag filters).
  *
- * Simply calling `setFilter(LINEAR)` once at construction is not enough:
- * every `setText` / `setColor` / `setStyle` routes through `updateText()`,
- * which calls `canvasToTexture(...)` and resets the GL min/mag filter back
- * to NEAREST. We therefore wrap `updateText` so the LINEAR filter is
- * re-applied after every internal re-upload. Sprite textures are untouched.
+ * Sub-pixel snapping is handled at the game level (`config.ts` enables
+ * `roundPixels: true`), not per-Text — Phaser 4 removed the per-object
+ * `setRoundPixels` method.
  */
 export function addCrispText(
   scene: Phaser.Scene,
@@ -40,7 +41,7 @@ export function addCrispText(
   style: Phaser.Types.GameObjects.Text.TextStyle,
 ): Phaser.GameObjects.Text {
   const t = scene.add.text(x, y, text, { resolution: currentTextRes, ...style });
-  const reapplyFilter = () => t.texture.setFilter(Phaser.Textures.FilterMode.LINEAR);
+  const reapplyFilter = () => t.texture.setFilter(Phaser.Textures.FilterMode.NEAREST);
   reapplyFilter();
   const original = t.updateText.bind(t);
   t.updateText = () => {

--- a/client/src/hooks/useAgentState.test.ts
+++ b/client/src/hooks/useAgentState.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'bun:test';
+import { classifyCloseEvent } from './useAgentState';
+
+// We compare WebSocket references by identity inside the helper, so the test
+// can fake them as opaque objects — none of the WebSocket API is exercised.
+function fakeWs(): WebSocket {
+  return {} as WebSocket;
+}
+
+describe('classifyCloseEvent', () => {
+  it('returns "reconnect" when the firing socket is the current one and reconnect is enabled', () => {
+    const ws = fakeWs();
+    expect(classifyCloseEvent(ws, ws, true)).toBe('reconnect');
+  });
+
+  it('returns "cleanup" when refs match but the effect has flipped shouldReconnect to false', () => {
+    const ws = fakeWs();
+    expect(classifyCloseEvent(ws, ws, false)).toBe('cleanup');
+  });
+
+  it('returns "stale" when the firing socket is not the one held by the hook (StrictMode race)', () => {
+    const newWs = fakeWs();
+    const oldWs = fakeWs();
+    // shouldReconnect re-flipped to true by mount B, but ws_A is firing — the
+    // identity check must override and skip reconnect.
+    expect(classifyCloseEvent(newWs, oldWs, true)).toBe('stale');
+  });
+
+  it('returns "stale" when the hook has nulled out its ref (cleanup before unmount finishes)', () => {
+    const oldWs = fakeWs();
+    expect(classifyCloseEvent(null, oldWs, true)).toBe('stale');
+  });
+
+  it('"stale" takes precedence over "cleanup" — identity check runs first', () => {
+    const newWs = fakeWs();
+    const oldWs = fakeWs();
+    // Even if shouldReconnect is false (would otherwise be "cleanup"), the
+    // stale ws still gets the stale verdict because identity check is first.
+    expect(classifyCloseEvent(newWs, oldWs, false)).toBe('stale');
+  });
+});

--- a/client/src/hooks/useAgentState.ts
+++ b/client/src/hooks/useAgentState.ts
@@ -24,6 +24,14 @@ export function useAgentState(): AgentStateHook {
   const [configDirs, setConfigDirs] = useState<string[] | null>(null);
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Distinguishes "the effect cleanup intentionally closed the socket" from
+  // "the server or network dropped us". Without this, `onclose` would always
+  // arm a reconnect timer — and on a StrictMode mount→unmount→mount cycle
+  // (or React Fast Refresh) that timer would fire on an orphan hook instance
+  // and call setState / emit bridge events for a hook that no longer exists,
+  // racing against the new mount. That race is the original symptom behind
+  // the "connect → error → disconnect" reconnect loop in issue #7.
+  const shouldReconnect = useRef(true);
 
   const handleEvent = useCallback((event: WsEvent) => {
     switch (event.type) {
@@ -88,27 +96,47 @@ export function useAgentState(): AgentStateHook {
       }
     };
 
-    ws.onclose = () => {
+    ws.onclose = (event) => {
+      // code/reason help diagnose why the server (or browser) dropped the
+      // connection — 1009 = message too big, 1006 = abnormal closure, 1000 =
+      // normal. wasClean=false signals an unclean teardown (issue #7 hunt).
+      if (!shouldReconnect.current) {
+        console.log(
+          `[WS] closed by cleanup code=${event.code} reason="${event.reason}" wasClean=${event.wasClean}`,
+        );
+        return;
+      }
       setConnected(false);
       eventBridge.emit('ws:disconnected');
-      console.log('[WS] disconnected, reconnecting in', RECONNECT_DELAY_MS, 'ms');
+      console.log(
+        `[WS] disconnected code=${event.code} reason="${event.reason}" wasClean=${event.wasClean} — reconnecting in`,
+        RECONNECT_DELAY_MS,
+        'ms',
+      );
       reconnectTimer.current = setTimeout(connect, RECONNECT_DELAY_MS);
     };
 
     ws.onerror = (err) => {
-      console.error('[WS] error:', err);
+      // Browsers do not expose error details for security; only the event type
+      // is meaningful. Pair this with the onclose code/reason for diagnosis.
+      console.error(`[WS] error type=${err.type}`);
       ws.close();
     };
   }, [handleEvent]);
 
   useEffect(() => {
+    shouldReconnect.current = true;
     connect();
 
     return () => {
+      // Mark cleanup so the upcoming `onclose` does NOT schedule a reconnect.
+      shouldReconnect.current = false;
       if (reconnectTimer.current !== null) {
         clearTimeout(reconnectTimer.current);
+        reconnectTimer.current = null;
       }
       wsRef.current?.close();
+      wsRef.current = null;
     };
   }, [connect]);
 

--- a/client/src/hooks/useAgentState.ts
+++ b/client/src/hooks/useAgentState.ts
@@ -7,6 +7,30 @@ import { WS_URL } from '../config';
 const RECONNECT_DELAY_MS = 3000;
 const MAX_LOG_ENTRIES = 200;
 
+/**
+ * Decision the WebSocket onclose handler should take. Extracted into a pure
+ * function so the StrictMode mount→unmount→mount race can be regression-tested
+ * without standing up a React render environment.
+ *
+ *   - `stale` — the firing socket is not the one currently held by the hook.
+ *     A previous mount's WebSocket fired its onclose late after a new mount
+ *     already replaced wsRef.current. Skip reconnect; the new ws owns it.
+ *   - `cleanup` — the effect cleanup intentionally closed the socket. Skip
+ *     reconnect; the hook is unmounting.
+ *   - `reconnect` — genuine server- or network-side close. Schedule reconnect.
+ */
+export type CloseAction = 'stale' | 'cleanup' | 'reconnect';
+
+export function classifyCloseEvent(
+  currentWs: WebSocket | null,
+  firingWs: WebSocket,
+  shouldReconnect: boolean,
+): CloseAction {
+  if (currentWs !== firingWs) return 'stale';
+  if (!shouldReconnect) return 'cleanup';
+  return 'reconnect';
+}
+
 export interface AgentStateHook {
   agents: AgentState[];
   activityLog: ActivityLogEntry[];
@@ -100,19 +124,19 @@ export function useAgentState(): AgentStateHook {
       // code/reason help diagnose why the server (or browser) dropped the
       // connection — 1009 = message too big, 1006 = abnormal closure, 1000 =
       // normal. wasClean=false signals an unclean teardown (issue #7 hunt).
-      if (!shouldReconnect.current) {
-        console.log(
-          `[WS] closed by cleanup code=${event.code} reason="${event.reason}" wasClean=${event.wasClean}`,
-        );
+      const action = classifyCloseEvent(wsRef.current, ws, shouldReconnect.current);
+      const closeMeta = `code=${event.code} reason="${event.reason}" wasClean=${event.wasClean}`;
+      if (action === 'stale') {
+        console.log(`[WS] closed (stale ws) ${closeMeta} — skipping reconnect`);
+        return;
+      }
+      if (action === 'cleanup') {
+        console.log(`[WS] closed by cleanup ${closeMeta}`);
         return;
       }
       setConnected(false);
       eventBridge.emit('ws:disconnected');
-      console.log(
-        `[WS] disconnected code=${event.code} reason="${event.reason}" wasClean=${event.wasClean} — reconnecting in`,
-        RECONNECT_DELAY_MS,
-        'ms',
-      );
+      console.log(`[WS] disconnected ${closeMeta} — reconnecting in`, RECONNECT_DELAY_MS, 'ms');
       reconnectTimer.current = setTimeout(connect, RECONNECT_DELAY_MS);
     };
 

--- a/client/src/hooks/useAgentState.ts
+++ b/client/src/hooks/useAgentState.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import type { AgentState, WsEvent, ActivityLogEntry } from '../types/agent';
+import { normalizeAgentState } from '../types/agent';
 import { eventBridge } from '../game/EventBridge';
 import { WS_URL } from '../config';
 
@@ -27,19 +28,21 @@ export function useAgentState(): AgentStateHook {
   const handleEvent = useCallback((event: WsEvent) => {
     switch (event.type) {
       case 'snapshot':
-        setAgents(event.agents);
+        setAgents(event.agents.map(normalizeAgentState));
         setConfigDirs(event.configDirs);
         break;
 
       case 'agent:new':
-        setAgents((prev) => [...prev, event.agent]);
+        setAgents((prev) => [...prev, normalizeAgentState(event.agent)]);
         break;
 
-      case 'agent:update':
+      case 'agent:update': {
+        const normalized = normalizeAgentState(event.agent);
         setAgents((prev) =>
-          prev.map((a) => (a.id === event.agent.id ? event.agent : a)),
+          prev.map((a) => (a.id === normalized.id ? normalized : a)),
         );
         break;
+      }
 
       case 'agent:complete':
         setAgents((prev) =>

--- a/client/src/hooks/useAgentState.ts
+++ b/client/src/hooks/useAgentState.ts
@@ -143,8 +143,10 @@ export function useAgentState(): AgentStateHook {
     ws.onerror = (err) => {
       // Browsers do not expose error details for security; only the event type
       // is meaningful. Pair this with the onclose code/reason for diagnosis.
+      // Do NOT call ws.close() here — the WebSocket spec guarantees onclose
+      // fires automatically after onerror, so an explicit close just adds a
+      // teardown race against the freshly-arriving server frame (issue #11).
       console.error(`[WS] error type=${err.type}`);
-      ws.close();
     };
   }, [handleEvent]);
 

--- a/client/src/hooks/useTopBarPrefs.test.ts
+++ b/client/src/hooks/useTopBarPrefs.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'bun:test';
+import { DEFAULT_TOPBAR_PREFS, parseTopBarPrefs, mergeTopBarPrefs } from './useTopBarPrefs';
+
+describe('parseTopBarPrefs', () => {
+  it('returns DEFAULT_TOPBAR_PREFS for null input', () => {
+    expect(parseTopBarPrefs(null)).toEqual(DEFAULT_TOPBAR_PREFS);
+  });
+
+  it('returns DEFAULT_TOPBAR_PREFS for malformed JSON', () => {
+    expect(parseTopBarPrefs('not json {')).toEqual(DEFAULT_TOPBAR_PREFS);
+  });
+
+  it('returns DEFAULT_TOPBAR_PREFS for non-object payload', () => {
+    expect(parseTopBarPrefs('"a string"')).toEqual(DEFAULT_TOPBAR_PREFS);
+    expect(parseTopBarPrefs('null')).toEqual(DEFAULT_TOPBAR_PREFS);
+  });
+
+  it('parses a valid payload', () => {
+    const raw = JSON.stringify({ showCompletedAgents: true });
+    expect(parseTopBarPrefs(raw)).toEqual({ showCompletedAgents: true });
+  });
+
+  it('falls back to default when showCompletedAgents has wrong type', () => {
+    const raw = JSON.stringify({ showCompletedAgents: 'yes' });
+    expect(parseTopBarPrefs(raw)).toEqual(DEFAULT_TOPBAR_PREFS);
+  });
+
+  it('default has showCompletedAgents false (current behavior preserved)', () => {
+    expect(DEFAULT_TOPBAR_PREFS.showCompletedAgents).toBe(false);
+  });
+});
+
+describe('mergeTopBarPrefs', () => {
+  it('overlays partial onto base', () => {
+    const merged = mergeTopBarPrefs(DEFAULT_TOPBAR_PREFS, { showCompletedAgents: true });
+    expect(merged.showCompletedAgents).toBe(true);
+  });
+});

--- a/client/src/hooks/useTopBarPrefs.ts
+++ b/client/src/hooks/useTopBarPrefs.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface TopBarPrefs {
+  showCompletedAgents: boolean;
+}
+
+export const DEFAULT_TOPBAR_PREFS: TopBarPrefs = {
+  showCompletedAgents: false,
+};
+
+const STORAGE_KEY = 'agentquest:topbar:prefs';
+const WRITE_DEBOUNCE_MS = 200;
+
+export function parseTopBarPrefs(raw: string | null): TopBarPrefs {
+  if (raw === null) return DEFAULT_TOPBAR_PREFS;
+  let obj: unknown;
+  try { obj = JSON.parse(raw); } catch { return DEFAULT_TOPBAR_PREFS; }
+  if (obj === null || typeof obj !== 'object') return DEFAULT_TOPBAR_PREFS;
+  const o = obj as Record<string, unknown>;
+  return {
+    showCompletedAgents:
+      typeof o.showCompletedAgents === 'boolean'
+        ? o.showCompletedAgents
+        : DEFAULT_TOPBAR_PREFS.showCompletedAgents,
+  };
+}
+
+export function mergeTopBarPrefs(base: TopBarPrefs, patch: Partial<TopBarPrefs>): TopBarPrefs {
+  return { ...base, ...patch };
+}
+
+export function useTopBarPrefs(): [TopBarPrefs, (patch: Partial<TopBarPrefs>) => void] {
+  const [prefs, setPrefs] = useState<TopBarPrefs>(() => {
+    if (typeof window === 'undefined') return DEFAULT_TOPBAR_PREFS;
+    return parseTopBarPrefs(window.localStorage.getItem(STORAGE_KEY));
+  });
+
+  const writeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingValue = useRef<TopBarPrefs | null>(null);
+
+  // Two effects on purpose: the dep-cleanup of the first only cancels the
+  // pending timer so the debounce can keep coalescing rapid changes, while
+  // the unmount-cleanup of the second drains the pending value to disk.
+  // Merging them into one would flush on every prefs change and defeat the
+  // debounce.
+
+  useEffect(() => {
+    if (writeTimer.current !== null) clearTimeout(writeTimer.current);
+    pendingValue.current = prefs;
+    writeTimer.current = setTimeout(() => {
+      try {
+        window.localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+      } catch { /* quota or private mode — silently ignore */ }
+      pendingValue.current = null;
+    }, WRITE_DEBOUNCE_MS);
+    return () => {
+      if (writeTimer.current !== null) clearTimeout(writeTimer.current);
+    };
+  }, [prefs]);
+
+  useEffect(() => {
+    return () => {
+      if (pendingValue.current !== null) {
+        try {
+          window.localStorage.setItem(STORAGE_KEY, JSON.stringify(pendingValue.current));
+        } catch { /* quota or private mode — silently ignore */ }
+        pendingValue.current = null;
+      }
+    };
+  }, []);
+
+  const update = useCallback((patch: Partial<TopBarPrefs>) => {
+    setPrefs((prev) => mergeTopBarPrefs(prev, patch));
+  }, []);
+
+  return [prefs, update];
+}

--- a/client/src/presentation/agentPresentation.test.ts
+++ b/client/src/presentation/agentPresentation.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from 'bun:test';
+import type { AgentState } from '../types/agent';
+import { computeShowSourceBadge, filterAgentsForPresentation } from './agentPresentation';
+
+function makeAgent(overrides: Partial<AgentState>): AgentState {
+  const base: AgentState = {
+    id: 'a1',
+    name: 'Hero',
+    heroClass: 'warrior',
+    heroColor: 'blue',
+    status: 'active',
+    currentActivity: 'idle',
+    tokenUsage: { input: 0, output: 0, cacheRead: 0 },
+    cost: 0,
+    sessionStart: 0,
+    toolCalls: [],
+    errors: [],
+    filesModified: [],
+    lastEvent: 0,
+    cwd: '/tmp',
+    configDir: '~/.claude',
+    source: 'claude',
+  } as AgentState;
+  return { ...base, ...overrides };
+}
+
+describe('filterAgentsForPresentation', () => {
+  it('default OFF: active, idle, and waiting pass; completed and error are hidden', () => {
+    const agents: AgentState[] = [
+      makeAgent({ id: 'active1', status: 'active' }),
+      makeAgent({ id: 'idle1', status: 'idle' }),
+      makeAgent({ id: 'wait1', status: 'waiting' }),
+      makeAgent({ id: 'done1', status: 'completed' }),
+      makeAgent({ id: 'err1', status: 'error' }),
+    ];
+    const visible = filterAgentsForPresentation(agents, false);
+    expect(visible.map((a) => a.id).sort()).toEqual(['active1', 'idle1', 'wait1']);
+  });
+
+  it('toggle ON: active, idle, waiting, and completed all pass', () => {
+    const agents: AgentState[] = [
+      makeAgent({ id: 'active1', status: 'active' }),
+      makeAgent({ id: 'idle1', status: 'idle' }),
+      makeAgent({ id: 'wait1', status: 'waiting' }),
+      makeAgent({ id: 'done1', status: 'completed' }),
+    ];
+    const visible = filterAgentsForPresentation(agents, true);
+    expect(visible.map((a) => a.id).sort()).toEqual(['active1', 'done1', 'idle1', 'wait1']);
+  });
+
+  it('toggle ON: error remains hidden', () => {
+    const agents: AgentState[] = [
+      makeAgent({ id: 'err1', status: 'error' }),
+      makeAgent({ id: 'done1', status: 'completed' }),
+    ];
+    const visible = filterAgentsForPresentation(agents, true);
+    expect(visible.map((a) => a.id).sort()).toEqual(['done1']);
+  });
+
+  it('waiting passes regardless of the completed toggle (regression for turn-end heroes)', () => {
+    const agents: AgentState[] = [makeAgent({ id: 'turnend', status: 'waiting' })];
+    expect(filterAgentsForPresentation(agents, false).map((a) => a.id)).toEqual(['turnend']);
+    expect(filterAgentsForPresentation(agents, true).map((a) => a.id)).toEqual(['turnend']);
+  });
+
+  it('preserves all idle and active agents regardless of toggle', () => {
+    const agents: AgentState[] = [
+      makeAgent({ id: 'a', status: 'active' }),
+      makeAgent({ id: 'b', status: 'idle' }),
+      makeAgent({ id: 'c', status: 'active' }),
+    ];
+    expect(filterAgentsForPresentation(agents, false).length).toBe(3);
+    expect(filterAgentsForPresentation(agents, true).length).toBe(3);
+  });
+
+  it('returns empty array for empty input', () => {
+    expect(filterAgentsForPresentation([], false)).toEqual([]);
+    expect(filterAgentsForPresentation([], true)).toEqual([]);
+  });
+});
+
+describe('computeShowSourceBadge', () => {
+  it('returns false when no agents', () => {
+    expect(computeShowSourceBadge([])).toBe(false);
+  });
+
+  it('returns false when only one provider has live agents', () => {
+    const agents: AgentState[] = [
+      makeAgent({ id: 'c1', source: 'claude', status: 'active' }),
+      makeAgent({ id: 'c2', source: 'claude', status: 'idle' }),
+    ];
+    expect(computeShowSourceBadge(agents)).toBe(false);
+  });
+
+  it('returns true when both providers have at least one live agent', () => {
+    const agents: AgentState[] = [
+      makeAgent({ id: 'c1', source: 'claude', status: 'active' }),
+      makeAgent({ id: 'x1', source: 'codex', status: 'idle' }),
+    ];
+    expect(computeShowSourceBadge(agents)).toBe(true);
+  });
+
+  it('ignores completed and error agents when computing liveness', () => {
+    const agents: AgentState[] = [
+      makeAgent({ id: 'c1', source: 'claude', status: 'active' }),
+      makeAgent({ id: 'x1', source: 'codex', status: 'completed' }),
+      makeAgent({ id: 'x2', source: 'codex', status: 'error' }),
+    ];
+    expect(computeShowSourceBadge(agents)).toBe(false);
+  });
+
+  it('handles a single live codex agent alongside a completed claude agent', () => {
+    const agents: AgentState[] = [
+      makeAgent({ id: 'c1', source: 'claude', status: 'completed' }),
+      makeAgent({ id: 'x1', source: 'codex', status: 'active' }),
+    ];
+    expect(computeShowSourceBadge(agents)).toBe(false);
+  });
+
+  it('counts waiting agents as live (consistent with filterAgentsForPresentation)', () => {
+    const agents: AgentState[] = [
+      makeAgent({ id: 'c1', source: 'claude', status: 'waiting' }),
+      makeAgent({ id: 'x1', source: 'codex', status: 'active' }),
+    ];
+    expect(computeShowSourceBadge(agents)).toBe(true);
+  });
+});

--- a/client/src/presentation/agentPresentation.ts
+++ b/client/src/presentation/agentPresentation.ts
@@ -1,0 +1,58 @@
+import type { AgentState } from '../types/agent';
+
+/**
+ * Project the full `agents` snapshot to the subset displayed in the Party
+ * Bar and the Phaser village scene. TopBar stats and DetailPanel lookup
+ * keep using the unfiltered list — this projection only governs the two
+ * presentation surfaces.
+ *
+ * This function is the single authoritative gate for which statuses reach
+ * those surfaces:
+ *
+ *   - `active`, `idle`, `waiting` — always pass through. `waiting` is a
+ *     short-lived "turn just ended, hero is resting at the tavern" state;
+ *     HeroSprite has dedicated pulse/label rendering for it, so it must
+ *     reach the Phaser scene. computeShowSourceBadge treats waiting as
+ *     live too — keep the two functions in agreement.
+ *   - `completed` — pass through only when `showCompleted` is true.
+ *   - `error` — always blocked here. The scene additionally drops `error`
+ *     defensively, and there is currently no Party Bar surfacing for it.
+ *
+ * Downstream consumers may apply additional local hiding (e.g. the Phaser
+ * scene drops heroes whose last event is older than its idle threshold),
+ * but they MUST NOT re-introduce `error` once it has been filtered out.
+ */
+export function filterAgentsForPresentation(
+  agents: AgentState[],
+  showCompleted: boolean,
+): AgentState[] {
+  return agents.filter((agent) => {
+    if (agent.status === 'active' || agent.status === 'idle' || agent.status === 'waiting') {
+      return true;
+    }
+    if (agent.status === 'completed' && showCompleted) return true;
+    return false;
+  });
+}
+
+/**
+ * Whether the source-provider badge (Claude/Codex orange/teal pill) should
+ * be shown anywhere in the UI. Only true when both providers have at least
+ * one LIVE agent — completed/error sessions don't count, otherwise the
+ * badge would linger after the last Codex hero finishes.
+ *
+ * Used by both App.tsx (React overlays) and VillageScene.ts (Phaser sprite
+ * badges); keep them in sync by calling this function instead of inlining
+ * the logic.
+ */
+export function computeShowSourceBadge(agents: AgentState[]): boolean {
+  let hasClaude = false;
+  let hasCodex = false;
+  for (const a of agents) {
+    if (a.status === 'completed' || a.status === 'error') continue;
+    if (a.source === 'claude') hasClaude = true;
+    else if (a.source === 'codex') hasCodex = true;
+    if (hasClaude && hasCodex) return true;
+  }
+  return false;
+}

--- a/client/src/types/agent.ts
+++ b/client/src/types/agent.ts
@@ -101,6 +101,31 @@ export interface AgentState {
   source: AgentSource;
   /** Raw model id from Claude Code (e.g. `claude-opus-4-6`). Undefined for Codex. */
   model?: string;
+  /**
+   * True when this session was spawned by another session as a sub-agent.
+   * Server-computed (file-system layout). Client never inspects sessionId
+   * patterns directly. Older server payloads predating this field are
+   * tolerated by `normalizeAgentState` below.
+   */
+  isSubagent: boolean;
+  /**
+   * Parent session id when this session is a sub-agent and the parent is
+   * known. Undefined for main sessions and for orphan sub-agents.
+   */
+  parentSessionId?: string;
+}
+
+/**
+ * Normalize a partial AgentState received over WebSocket — back-compat shim
+ * for older server payloads (or replays) that do not carry the new sub-agent
+ * fields. Anything missing falls back to "main session" semantics so the
+ * existing rendering path stays correct.
+ */
+export function normalizeAgentState(raw: Omit<AgentState, 'isSubagent'> & { isSubagent?: boolean }): AgentState {
+  return {
+    ...raw,
+    isSubagent: raw.isSubagent ?? false,
+  };
 }
 
 /**

--- a/client/src/utils/truncateLabel.test.ts
+++ b/client/src/utils/truncateLabel.test.ts
@@ -1,0 +1,53 @@
+import { describe, test, expect } from 'bun:test';
+
+import { truncateLabel } from './truncateLabel';
+
+describe('truncateLabel', () => {
+  test('returns the input untouched when shorter than the limit', () => {
+    expect(truncateLabel('short', 40)).toBe('short');
+  });
+
+  test('returns the input untouched when exactly the limit', () => {
+    const exact = 'x'.repeat(40);
+    expect(truncateLabel(exact, 40)).toBe(exact);
+  });
+
+  test('clips with an ellipsis when longer than the limit', () => {
+    const long = 'x'.repeat(50);
+    const out = truncateLabel(long, 10);
+    expect(out).toBe('xxxxxxxxx…');
+    expect([...out].length).toBe(10);
+  });
+
+  test('collapses whitespace runs to single spaces', () => {
+    expect(truncateLabel('feat:\n  fix\t\tcrash', 40)).toBe('feat: fix crash');
+  });
+
+  test('trims leading and trailing whitespace before measuring length', () => {
+    // Without trim, the input has 8 chars and would not be truncated at 7;
+    // after trim it's 5 chars and stays intact.
+    expect(truncateLabel('   foo   ', 7)).toBe('foo');
+  });
+
+  test('does not slice an emoji in half (code-point safe)', () => {
+    // Each rocket is one user-perceived character but two UTF-16 code units.
+    // A naive `slice` would cut the second rocket mid-surrogate-pair and the
+    // canvas would render the U+FFFD replacement glyph.
+    const input = '🚀🚀🚀🚀🚀';
+    const out = truncateLabel(input, 3);
+    expect(out).toBe('🚀🚀…');
+    // The ellipsis is one code point — total three "characters".
+    expect([...out].length).toBe(3);
+  });
+
+  test('handles empty input', () => {
+    expect(truncateLabel('', 40)).toBe('');
+    expect(truncateLabel('   ', 40)).toBe('');
+  });
+
+  test('handles a max of 1 (degenerate but legal)', () => {
+    // After trim the single remaining char fits; ellipsis only kicks in past the cap.
+    expect(truncateLabel('a', 1)).toBe('a');
+    expect(truncateLabel('ab', 1)).toBe('…');
+  });
+});

--- a/client/src/utils/truncateLabel.ts
+++ b/client/src/utils/truncateLabel.ts
@@ -1,0 +1,15 @@
+/**
+ * Collapse whitespace and clip to `max` chars — every head-stack label sits on
+ * a single line, so wrapped multi-line strings would push neighbouring badges
+ * out of frame. The ellipsis preserves intent ("there was more") without
+ * leaking formatting noise (newlines, tabs) into the canvas. Spread iterates
+ * code points (not UTF-16 code units), so emoji and other supplementary-plane
+ * characters don't get sliced mid-surrogate-pair and render as replacement
+ * glyphs above the hero.
+ */
+export function truncateLabel(text: string, max: number): string {
+  const single = text.replace(/\s+/g, ' ').trim();
+  const chars = [...single];
+  if (chars.length <= max) return single;
+  return chars.slice(0, max - 1).join('') + '…';
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -53,6 +53,7 @@ const stateManager = new AgentStateManager({
   subagentCompletedThresholdMs: SUBAGENT_COMPLETED_THRESHOLD_MS,
   subagentBusyCompletedThresholdMs: SUBAGENT_BUSY_COMPLETED_THRESHOLD_MS,
   livenessOracle: sessionRegistry,
+  displayNameOracle: sessionRegistry,
 });
 const wsServer = new WebSocketServer();
 const mapStorage = new MapStorage();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -120,7 +120,13 @@ const providerHandlers: ProviderHandlers = {
       // filename-derived id so each subagent becomes its own hero instead
       // of being folded into the parent agent.
       event.sessionId = payload.sessionId;
-      const result = stateManager.processEvent(event, payload.configDir, payload.source, payload.nameOverride);
+      const result = stateManager.processEvent(
+        event,
+        payload.configDir,
+        payload.source,
+        payload.nameOverride,
+        payload.subagentCtx,
+      );
       if (result !== null && result.isNew) {
         wsServer.broadcastNewAgent(result.agent);
       }
@@ -134,7 +140,13 @@ const providerHandlers: ProviderHandlers = {
     for (const event of payload.events) {
       // See note in onSessionStart: rekey to filename-derived id for subagents.
       event.sessionId = payload.sessionId;
-      const result = stateManager.processEvent(event, payload.configDir, payload.source);
+      const result = stateManager.processEvent(
+        event,
+        payload.configDir,
+        payload.source,
+        undefined,
+        payload.subagentCtx,
+      );
       if (result === null) continue; // resume-hint dump, no state change
 
       if (result.isNew) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -252,8 +252,8 @@ const server = Bun.serve({
       wsServer.handleOpen(ws);
       wsServer.sendSnapshot(ws, stateManager.getAll(), allConfigDirs());
     },
-    close(ws: WsClient) {
-      wsServer.handleClose(ws);
+    close(ws: WsClient, code: number, reason: string) {
+      wsServer.handleClose(ws, code, reason);
     },
     message() {
       // Client-to-server messages not needed in Phase 1

--- a/server/src/map/protected-buildings.test.ts
+++ b/server/src/map/protected-buildings.test.ts
@@ -1,0 +1,61 @@
+import { describe, test, expect } from 'bun:test';
+import { DEFAULT_PROTECTED_BUILDINGS } from './protected-buildings';
+
+/**
+ * Smoke-test that the server's DEFAULT_PROTECTED_BUILDINGS stays in sync with
+ * the client's BUILDING_DEFS (client/src/game/data/building-layout.ts).
+ *
+ * We cannot import the client module here (different TS project), so we pin
+ * the expected values explicitly. When BUILDING_DEFS coordinates change, this
+ * test fails immediately — alerting developers to update protected-buildings.ts.
+ */
+describe('DEFAULT_PROTECTED_BUILDINGS', () => {
+  const byId = Object.fromEntries(DEFAULT_PROTECTED_BUILDINGS.map((b) => [b.id, b]));
+
+  test('contains all 8 interactive buildings', () => {
+    const ids = ['library', 'castle', 'forge', 'arena', 'alchemist', 'chapel', 'watchtower', 'tavern'];
+    for (const id of ids) {
+      expect(byId[id], `missing building: ${id}`).toBeDefined();
+    }
+    expect(DEFAULT_PROTECTED_BUILDINGS).toHaveLength(8);
+  });
+
+  test('coordinates match client BUILDING_DEFS defaults', () => {
+    // Pin to the values in client/src/game/data/building-layout.ts.
+    // Update both files together when repositioning buildings.
+    const expected: Record<string, { x: number; y: number }> = {
+      library:    { x: 1150, y: 900 },
+      castle:     { x: 1300, y: 700 },
+      forge:      { x: 1380, y: 880 },
+      arena:      { x: 1560, y: 880 },
+      alchemist:  { x: 1470, y: 700 },
+      chapel:     { x: 1720, y: 560 },
+      watchtower: { x: 1600, y: 450 },
+      tavern:     { x: 1250, y: 780 },
+    };
+
+    for (const [id, coords] of Object.entries(expected)) {
+      const building = byId[id];
+      expect(building, `missing: ${id}`).toBeDefined();
+      expect(building!.x, `${id}.x`).toBe(coords.x);
+      expect(building!.y, `${id}.y`).toBe(coords.y);
+    }
+  });
+
+  test('each building has matching activity field', () => {
+    const expectedActivities: Record<string, string> = {
+      library:    'reading',
+      castle:     'thinking',
+      forge:      'editing',
+      arena:      'bash',
+      alchemist:  'debugging',
+      chapel:     'git',
+      watchtower: 'reviewing',
+      tavern:     'idle',
+    };
+
+    for (const [id, activity] of Object.entries(expectedActivities)) {
+      expect(byId[id]?.activity, `${id}.activity`).toBe(activity);
+    }
+  });
+});

--- a/server/src/map/protected-buildings.ts
+++ b/server/src/map/protected-buildings.ts
@@ -14,15 +14,17 @@ export interface ProtectedBuildingDefault {
   defaultScale: number;
 }
 
+// Coordinates mirror BUILDING_DEFS in client/src/game/data/building-layout.ts.
+// Keep both in sync whenever buildings are repositioned.
 export const DEFAULT_PROTECTED_BUILDINGS: ProtectedBuildingDefault[] = [
-  { id: 'library',    label: 'Library',    activity: 'reading',   x: 1060, y: 600,  defaultScale: 0.52 },
-  { id: 'alchemist',  label: 'Alchemist',  activity: 'debugging', x: 1210, y: 460,  defaultScale: 0.50 },
-  { id: 'castle',     label: 'Castle',     activity: 'thinking',  x: 1430, y: 430,  defaultScale: 0.46 },
-  { id: 'watchtower', label: 'Watchtower', activity: 'reviewing', x: 1650, y: 470,  defaultScale: 0.42 },
-  { id: 'chapel',     label: 'Chapel',     activity: 'git',       x: 1790, y: 610,  defaultScale: 0.38 },
-  { id: 'tavern',     label: 'Tavern',     activity: 'idle',      x: 1510, y: 810,  defaultScale: 0.50 },
-  { id: 'forge',      label: 'Forge',      activity: 'editing',   x: 1150, y: 970,  defaultScale: 0.42 },
-  { id: 'arena',      label: 'Arena',      activity: 'bash',      x: 1700, y: 970,  defaultScale: 0.42 },
+  { id: 'library',    label: 'Library',    activity: 'reading',   x: 1150, y: 900,  defaultScale: 0.52 },
+  { id: 'castle',     label: 'Castle',     activity: 'thinking',  x: 1300, y: 700,  defaultScale: 0.46 },
+  { id: 'forge',      label: 'Forge',      activity: 'editing',   x: 1380, y: 880,  defaultScale: 0.42 },
+  { id: 'arena',      label: 'Arena',      activity: 'bash',      x: 1560, y: 880,  defaultScale: 0.42 },
+  { id: 'alchemist',  label: 'Alchemist',  activity: 'debugging', x: 1470, y: 700,  defaultScale: 0.50 },
+  { id: 'chapel',     label: 'Chapel',     activity: 'git',       x: 1720, y: 560,  defaultScale: 0.38 },
+  { id: 'watchtower', label: 'Watchtower', activity: 'reviewing', x: 1600, y: 450,  defaultScale: 0.42 },
+  { id: 'tavern',     label: 'Tavern',     activity: 'idle',      x: 1250, y: 780,  defaultScale: 0.50 },
 ];
 
 export const PROTECTED_BUILDING_IDS: readonly string[] = DEFAULT_PROTECTED_BUILDINGS.map((b) => b.id);

--- a/server/src/providers/claude-provider.ts
+++ b/server/src/providers/claude-provider.ts
@@ -26,10 +26,10 @@ export class ClaudeProvider implements SessionProvider {
       maxAgeMs: this.opts.maxAgeMs,
       claudeDirs: this.opts.claudeDirs,
 
-      onNewSession: async (sessionId, filePath, configDir) => {
+      onNewSession: async (sessionId, filePath, configDir, subagentCtx) => {
         const contents = await Bun.file(filePath).text();
         const events = parseSessionFile(contents);
-        const nameOverride = sessionId.startsWith('agent-')
+        const nameOverride = subagentCtx.isSubagent
           ? await resolveSubagentLabel(filePath).catch(() => undefined)
           : undefined;
         await handlers.onSessionStart({
@@ -38,10 +38,11 @@ export class ClaudeProvider implements SessionProvider {
           configDir,
           events,
           nameOverride,
+          subagentCtx,
         });
       },
 
-      onSessionUpdate: (sessionId, _filePath, newContent, configDir) => {
+      onSessionUpdate: (sessionId, _filePath, newContent, configDir, subagentCtx) => {
         const events: ParsedEvent[] = [];
         for (const line of newContent.split('\n')) {
           if (line.trim() === '') continue;
@@ -54,6 +55,7 @@ export class ClaudeProvider implements SessionProvider {
           sessionId,
           configDir,
           events,
+          subagentCtx,
         });
       },
     });

--- a/server/src/providers/types.ts
+++ b/server/src/providers/types.ts
@@ -1,4 +1,4 @@
-import type { AgentSource } from '../types';
+import type { AgentSource, SubagentContext } from '../types';
 import type { ParsedEvent } from '../parsers/session-parser';
 
 export interface SessionStartPayload {
@@ -8,6 +8,13 @@ export interface SessionStartPayload {
   events: ParsedEvent[];
   /** Optional name override resolved by the provider (e.g. Claude subagent label). */
   nameOverride?: string;
+  /**
+   * Subagent context resolved by the provider — `isSubagent` is always set;
+   * `parentSessionId` is set only when discoverable from disk layout.
+   * Defaults to `{ isSubagent: false }` for main sessions and for providers
+   * that have no sub-agent concept (e.g. Codex).
+   */
+  subagentCtx?: SubagentContext;
 }
 
 export interface SessionEventsPayload {
@@ -16,6 +23,12 @@ export interface SessionEventsPayload {
   configDir: string;
   /** Incremental events since the last update. */
   events: ParsedEvent[];
+  /**
+   * Subagent context — propagated on updates so that any first-event-on-update
+   * path (extremely rare) sees the same metadata. Existing agents already have
+   * the fields set from `onSessionStart`.
+   */
+  subagentCtx?: SubagentContext;
 }
 
 export interface ProviderHandlers {

--- a/server/src/session-registry.test.ts
+++ b/server/src/session-registry.test.ts
@@ -5,13 +5,38 @@ import { join } from 'node:path';
 
 import { SessionRegistry } from './session-registry';
 
-async function makeClaudeDir(withSessions: Array<{ pid: number; sessionId: string }>): Promise<string> {
+interface SessionStub {
+  pid: number;
+  sessionId: string;
+  /** When set, the stub also writes `<root>/jobs/<jobId>/state.json` so the display-name oracle has something to read. */
+  jobId?: string;
+  /** When set, the corresponding `jobs/<jobId>/state.json` carries this `name`. */
+  displayName?: string;
+}
+
+async function makeClaudeDir(withSessions: SessionStub[]): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), 'agent-quest-test-'));
   const sessionsDir = join(root, 'sessions');
   await mkdir(sessionsDir, { recursive: true });
-  for (const { pid, sessionId } of withSessions) {
+  for (const stub of withSessions) {
+    const { pid, sessionId, jobId, displayName } = stub;
     const file = join(sessionsDir, `${pid}.json`);
-    await writeFile(file, JSON.stringify({ pid, sessionId, cwd: '/tmp', startedAt: Date.now(), kind: 'interactive', entrypoint: 'cli' }));
+    const payload: Record<string, unknown> = {
+      pid,
+      sessionId,
+      cwd: '/tmp',
+      startedAt: Date.now(),
+      kind: 'interactive',
+      entrypoint: 'cli',
+    };
+    if (jobId !== undefined) payload['jobId'] = jobId;
+    await writeFile(file, JSON.stringify(payload));
+
+    if (jobId !== undefined && displayName !== undefined) {
+      const jobDir = join(root, 'jobs', jobId);
+      await mkdir(jobDir, { recursive: true });
+      await writeFile(join(jobDir, 'state.json'), JSON.stringify({ name: displayName }));
+    }
   }
   return root;
 }
@@ -116,6 +141,89 @@ describe('SessionRegistry', () => {
     });
     await reg.scan();
     expect(reg.hasAnyLive()).toBe(false);
+  });
+
+  test('exposes display name read from jobs/<jobId>/state.json', async () => {
+    const dir = await makeClaudeDir([
+      { pid: 11, sessionId: 'with-job', jobId: 'job-abc', displayName: '[#42, 7/13] feat: foo' },
+      { pid: 12, sessionId: 'no-job' },
+    ]);
+    tempDirs.push(dir);
+
+    const reg = new SessionRegistry({ configDirs: [dir], pidAlive: () => true });
+    await reg.scan();
+
+    expect(reg.getDisplayName('with-job')).toBe('[#42, 7/13] feat: foo');
+    // No jobId → no display name (caller falls back to slug/cwd).
+    expect(reg.getDisplayName('no-job')).toBeUndefined();
+    // Unknown sessionId → undefined.
+    expect(reg.getDisplayName('never-seen')).toBeUndefined();
+  });
+
+  test('forgets display name when state.json is removed between scans', async () => {
+    const dir = await makeClaudeDir([
+      { pid: 21, sessionId: 'sid-21', jobId: 'job-21', displayName: '[#7, 2/13] initial' },
+    ]);
+    tempDirs.push(dir);
+
+    const reg = new SessionRegistry({ configDirs: [dir], pidAlive: () => true });
+    await reg.scan();
+    expect(reg.getDisplayName('sid-21')).toBe('[#7, 2/13] initial');
+
+    await rm(join(dir, 'jobs', 'job-21', 'state.json'));
+    await reg.scan();
+    expect(reg.getDisplayName('sid-21')).toBeUndefined();
+  });
+
+  test('picks up display name changes between scans (live retitle)', async () => {
+    const dir = await makeClaudeDir([
+      { pid: 31, sessionId: 'sid-31', jobId: 'job-31', displayName: '[#9, 2/13] foo' },
+    ]);
+    tempDirs.push(dir);
+
+    const reg = new SessionRegistry({ configDirs: [dir], pidAlive: () => true });
+    await reg.scan();
+    expect(reg.getDisplayName('sid-31')).toBe('[#9, 2/13] foo');
+
+    await writeFile(
+      join(dir, 'jobs', 'job-31', 'state.json'),
+      JSON.stringify({ name: '[#9, 12/13] foo' }),
+    );
+    await reg.scan();
+    expect(reg.getDisplayName('sid-31')).toBe('[#9, 12/13] foo');
+  });
+
+  test('tolerates corrupt state.json (returns undefined)', async () => {
+    const dir = await makeClaudeDir([
+      { pid: 41, sessionId: 'sid-41', jobId: 'job-41' },
+    ]);
+    tempDirs.push(dir);
+    // Write a malformed state.json manually.
+    const jobDir = join(dir, 'jobs', 'job-41');
+    await mkdir(jobDir, { recursive: true });
+    await writeFile(join(jobDir, 'state.json'), '{not json');
+
+    const reg = new SessionRegistry({ configDirs: [dir], pidAlive: () => true });
+    await reg.scan();
+
+    // Liveness still works; only displayName degrades gracefully.
+    expect(reg.isLive('sid-41')).toBe(true);
+    expect(reg.getDisplayName('sid-41')).toBeUndefined();
+  });
+
+  test('drops display name for sessions whose pid is dead', async () => {
+    const dir = await makeClaudeDir([
+      { pid: 51, sessionId: 'sid-51', jobId: 'job-51', displayName: '[#1, 5/13] x' },
+    ]);
+    tempDirs.push(dir);
+
+    const reg = new SessionRegistry({ configDirs: [dir], pidAlive: () => false });
+    await reg.scan();
+
+    // Dead pid: registry must not surface stale display names — otherwise the
+    // dashboard would keep ghost sessions visible under their last-known title.
+    expect(reg.isLive('sid-51')).toBe(false);
+    expect(reg.getDisplayName('sid-51')).toBeUndefined();
   });
 
   test('setConfigDirs refreshes the watched roots', async () => {

--- a/server/src/session-registry.ts
+++ b/server/src/session-registry.ts
@@ -1,18 +1,38 @@
 import { readdir } from 'node:fs/promises';
 import { join } from 'node:path';
 
-import type { SessionLivenessOracle } from './state/agent-state-manager';
+import type { SessionDisplayNameOracle, SessionLivenessOracle } from './state/agent-state-manager';
 
-/** Reads `sessionId` out of a `<pid>.json` file. Tolerates noise and missing fields. */
-async function readSessionIdFrom(filePath: string): Promise<string | null> {
+/** Reads `sessionId` and `jobId` out of a `<pid>.json` file. Tolerates noise and missing fields. */
+async function readSessionMetaFrom(filePath: string): Promise<{ sessionId: string; jobId: string | null } | null> {
   try {
     const text = await Bun.file(filePath).text();
-    const data = JSON.parse(text) as { sessionId?: unknown };
+    const data = JSON.parse(text) as { sessionId?: unknown; jobId?: unknown };
     if (typeof data.sessionId === 'string' && data.sessionId.length > 0) {
-      return data.sessionId;
+      const jobId = typeof data.jobId === 'string' && data.jobId.length > 0 ? data.jobId : null;
+      return { sessionId: data.sessionId, jobId };
     }
   } catch {
     // unreadable / not JSON / partially-written — just ignore this file
+  }
+  return null;
+}
+
+/**
+ * Reads the human-friendly display name out of `<configDir>/jobs/<jobId>/state.json`.
+ * This is the same `name` field that Claude Code's `claude agents` view renders in
+ * the left column — see `~/.claude/rules/session-display-name.md`. Returns null
+ * when the file is missing, unparseable, or omits the field.
+ */
+async function readDisplayNameFrom(filePath: string): Promise<string | null> {
+  try {
+    const text = await Bun.file(filePath).text();
+    const data = JSON.parse(text) as { name?: unknown };
+    if (typeof data.name === 'string' && data.name.length > 0) {
+      return data.name;
+    }
+  } catch {
+    // missing / unreadable / not JSON — fall back to slug/cwd at the caller.
   }
   return null;
 }
@@ -44,10 +64,11 @@ export interface SessionRegistryOptions {
  * agents whose JSONLs were touched by Claude Code resume/hook machinery but
  * whose real process has long since exited.
  */
-export class SessionRegistry implements SessionLivenessOracle {
+export class SessionRegistry implements SessionLivenessOracle, SessionDisplayNameOracle {
   private configDirs: string[];
   private pidAlive: PidLivenessCheck;
   private liveSessionIds = new Set<string>();
+  private displayNames = new Map<string, string>();
   private scanned = false;
   private pollInterval: ReturnType<typeof setInterval> | null = null;
 
@@ -67,6 +88,15 @@ export class SessionRegistry implements SessionLivenessOracle {
 
   isLive(sessionId: string): boolean {
     return this.liveSessionIds.has(sessionId);
+  }
+
+  /**
+   * Returns the user-set display name for a live Claude session, or undefined
+   * when the session has no jobId, no state.json, or the file omits the field.
+   * Callers fall back to slug/cwd in that case.
+   */
+  getDisplayName(sessionId: string): string | undefined {
+    return this.displayNames.get(sessionId);
   }
 
   /** Current live session IDs (copy, for debugging/snapshots). */
@@ -92,6 +122,7 @@ export class SessionRegistry implements SessionLivenessOracle {
 
   async scan(): Promise<void> {
     const next = new Set<string>();
+    const nextNames = new Map<string, string>();
     for (const configDir of this.configDirs) {
       const sessionsDir = join(configDir, 'sessions');
       let entries: string[];
@@ -106,11 +137,18 @@ export class SessionRegistry implements SessionLivenessOracle {
         const pid = Number.parseInt(pidMatch[1]!, 10);
         if (!Number.isFinite(pid) || pid <= 0) continue;
         if (!this.pidAlive(pid)) continue;
-        const sessionId = await readSessionIdFrom(join(sessionsDir, entry));
-        if (sessionId !== null) next.add(sessionId);
+        const meta = await readSessionMetaFrom(join(sessionsDir, entry));
+        if (meta === null) continue;
+        next.add(meta.sessionId);
+        if (meta.jobId !== null) {
+          const statePath = join(configDir, 'jobs', meta.jobId, 'state.json');
+          const displayName = await readDisplayNameFrom(statePath);
+          if (displayName !== null) nextNames.set(meta.sessionId, displayName);
+        }
       }
     }
     this.liveSessionIds = next;
+    this.displayNames = nextNames;
     this.scanned = true;
   }
 }

--- a/server/src/state/agent-state-manager.test.ts
+++ b/server/src/state/agent-state-manager.test.ts
@@ -857,4 +857,80 @@ describe('AgentStateManager', () => {
     expect(changed).toContain('sess-1');
     expect(m.getAgent('sess-1')!.name).toBe('[#1, 5/13] late wiring');
   });
+
+  describe('subagent context propagation', () => {
+    test('main session has isSubagent=false and parentSessionId undefined when no ctx passed', () => {
+      const mgr = new AgentStateManager();
+      const result = mgr.processEvent(makeEvent({ sessionId: 'main-1' }));
+
+      expect(result).not.toBeNull();
+      expect(result!.agent.isSubagent).toBe(false);
+      expect(result!.agent.parentSessionId).toBeUndefined();
+    });
+
+    test('subagent registered with ctx records both isSubagent and parentSessionId', () => {
+      const mgr = new AgentStateManager();
+      const result = mgr.processEvent(
+        makeEvent({ sessionId: 'agent-aXYZ12345678abcd' }),
+        '/home/x/.claude',
+        'claude',
+        undefined,
+        { isSubagent: true, parentSessionId: 'parent-sess-1' },
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.agent.isSubagent).toBe(true);
+      expect(result!.agent.parentSessionId).toBe('parent-sess-1');
+    });
+
+    test('orphan subagent (ctx has isSubagent but no parentSessionId) keeps isSubagent=true', () => {
+      const mgr = new AgentStateManager();
+      const result = mgr.processEvent(
+        makeEvent({ sessionId: 'agent-bORPHAN1234abcdef' }),
+        '/home/x/.claude',
+        'claude',
+        undefined,
+        { isSubagent: true },
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.agent.isSubagent).toBe(true);
+      expect(result!.agent.parentSessionId).toBeUndefined();
+    });
+
+    test('main session with explicit ctx { isSubagent: false } sets fields correctly', () => {
+      const mgr = new AgentStateManager();
+      const result = mgr.processEvent(
+        makeEvent({ sessionId: 'main-2' }),
+        '/home/x/.claude',
+        'claude',
+        undefined,
+        { isSubagent: false },
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.agent.isSubagent).toBe(false);
+      expect(result!.agent.parentSessionId).toBeUndefined();
+    });
+
+    test('updates to existing subagent preserve isSubagent and parentSessionId', () => {
+      const mgr = new AgentStateManager();
+      mgr.processEvent(
+        makeEvent({ sessionId: 'agent-cUPDATE12345678ab' }),
+        '/home/x/.claude',
+        'claude',
+        undefined,
+        { isSubagent: true, parentSessionId: 'parent-2' },
+      );
+      const result = mgr.processEvent(
+        makeEvent({ sessionId: 'agent-cUPDATE12345678ab', activity: 'editing', file: '/bar.ts' }),
+      );
+
+      expect(result).not.toBeNull();
+      expect(result!.isNew).toBe(false);
+      expect(result!.agent.isSubagent).toBe(true);
+      expect(result!.agent.parentSessionId).toBe('parent-2');
+      expect(result!.agent.currentActivity).toBe('editing');
+    });
+  });
 });

--- a/server/src/state/agent-state-manager.test.ts
+++ b/server/src/state/agent-state-manager.test.ts
@@ -462,6 +462,104 @@ describe('AgentStateManager', () => {
     expect(agent!.toolCalls).toHaveLength(2);
   });
 
+  test('caps toolCalls on first event when initial batch exceeds limit (creation path)', () => {
+    const mgr = new AgentStateManager();
+    const bigBatch = Array.from({ length: 55 }, (_, i) => ({
+      id: `tc-${i}`,
+      name: 'Read',
+      timestamp: Date.now() + i,
+      input: { file_path: `/file-${i}.ts` },
+    }));
+    mgr.processEvent(makeEvent({ toolCalls: bigBatch }));
+
+    const agent = mgr.getAgent('sess-1');
+    expect(agent!.toolCalls).toHaveLength(50);
+    // Oldest 5 dropped — newest survives
+    expect(agent!.toolCalls[0]!.id).toBe('tc-5');
+    expect(agent!.toolCalls[49]!.id).toBe('tc-54');
+  });
+
+  test('caps toolCalls across accumulated updates (update path drops oldest)', () => {
+    const mgr = new AgentStateManager();
+    // Seed: 40 calls
+    const initial = Array.from({ length: 40 }, (_, i) => ({
+      id: `tc-${i}`,
+      name: 'Read',
+      timestamp: Date.now() + i,
+      input: { file_path: `/file-${i}.ts` },
+    }));
+    mgr.processEvent(makeEvent({ toolCalls: initial }));
+
+    // Update: 15 more calls (total would be 55, cap to 50)
+    const more = Array.from({ length: 15 }, (_, i) => ({
+      id: `tc-extra-${i}`,
+      name: 'Bash',
+      timestamp: Date.now() + 100 + i,
+      input: { command: `cmd-${i}` },
+    }));
+    mgr.processEvent(makeEvent({ toolCalls: more, activity: 'bash' }));
+
+    const agent = mgr.getAgent('sess-1');
+    expect(agent!.toolCalls).toHaveLength(50);
+    // Oldest 5 dropped — first surviving call is the 6th original
+    expect(agent!.toolCalls[0]!.id).toBe('tc-5');
+    // Newest extras at the tail
+    expect(agent!.toolCalls[49]!.id).toBe('tc-extra-14');
+  });
+
+  test('caps filesModified with dedup, preserving newest after cap', () => {
+    const mgr = new AgentStateManager();
+    // First batch: 30 unique files
+    const firstBatch = Array.from({ length: 30 }, (_, i) => ({
+      id: `tc-${i}`,
+      name: 'Edit',
+      timestamp: Date.now() + i,
+      input: { file_path: `/file-${i}.ts` },
+    }));
+    mgr.processEvent(makeEvent({ toolCalls: firstBatch, activity: 'editing' }));
+
+    // Second batch: duplicates of /file-0 and /file-1 (dedup skip)
+    // plus 25 new files (cap kicks in)
+    const secondBatch = [
+      { id: 'tc-dup-0', name: 'Edit', timestamp: Date.now() + 100, input: { file_path: '/file-0.ts' } },
+      { id: 'tc-dup-1', name: 'Edit', timestamp: Date.now() + 101, input: { file_path: '/file-1.ts' } },
+      ...Array.from({ length: 25 }, (_, i) => ({
+        id: `tc-new-${i}`,
+        name: 'Edit',
+        timestamp: Date.now() + 200 + i,
+        input: { file_path: `/new-${i}.ts` },
+      })),
+    ];
+    mgr.processEvent(makeEvent({ toolCalls: secondBatch, activity: 'editing' }));
+
+    const agent = mgr.getAgent('sess-1');
+    // 30 (unique) + 25 (new unique) = 55, capped to 50; duplicates skipped
+    expect(agent!.filesModified).toHaveLength(50);
+    // Oldest 5 dropped — first surviving is /file-5.ts
+    expect(agent!.filesModified[0]).toBe('/file-5.ts');
+    // Newest at the tail
+    expect(agent!.filesModified[49]).toBe('/new-24.ts');
+  });
+
+  test('empty toolCalls in update event preserves existing accumulated history', () => {
+    const mgr = new AgentStateManager();
+    // Seed: 10 calls
+    const seed = Array.from({ length: 10 }, (_, i) => ({
+      id: `tc-${i}`,
+      name: 'Read',
+      timestamp: Date.now() + i,
+      input: { file_path: `/file-${i}.ts` },
+    }));
+    mgr.processEvent(makeEvent({ toolCalls: seed }));
+
+    // Empty update — should not mutate the existing array
+    mgr.processEvent(makeEvent({ toolCalls: [], activity: 'thinking' }));
+
+    const agent = mgr.getAgent('sess-1');
+    expect(agent!.toolCalls).toHaveLength(10);
+    expect(agent!.toolCalls.map((tc) => tc.id)).toEqual(seed.map((tc) => tc.id));
+  });
+
   test('getAll returns all agents', () => {
     const mgr = new AgentStateManager();
     mgr.processEvent(makeEvent({ sessionId: 'sess-1' }));

--- a/server/src/state/agent-state-manager.test.ts
+++ b/server/src/state/agent-state-manager.test.ts
@@ -740,4 +740,121 @@ describe('AgentStateManager', () => {
     expect(res!.agent.source).toBe('codex');
     expect(res!.agent.status).toBe('active');  // NOT completed despite oracle saying "not live"
   });
+
+  test('display-name oracle overrides slug on agent creation', () => {
+    const displayNames = new Map<string, string>([['sess-1', '[#42, 7/13] feat: foo']]);
+    const m = new AgentStateManager({
+      displayNameOracle: { getDisplayName: (sid) => displayNames.get(sid) },
+    });
+
+    const result = m.processEvent(makeEvent());
+
+    expect(result!.agent.name).toBe('[#42, 7/13] feat: foo');
+  });
+
+  test('display-name oracle falls back to slug when no name is set', () => {
+    const m = new AgentStateManager({
+      displayNameOracle: { getDisplayName: () => undefined },
+    });
+
+    const result = m.processEvent(makeEvent());
+
+    expect(result!.agent.name).toBe('bubbly-waddling-cat');
+  });
+
+  test('display-name oracle updates the agent label on subsequent events', () => {
+    const displayNames = new Map<string, string>();
+    const m = new AgentStateManager({
+      displayNameOracle: { getDisplayName: (sid) => displayNames.get(sid) },
+    });
+
+    const initial = m.processEvent(makeEvent());
+    expect(initial!.agent.name).toBe('bubbly-waddling-cat');
+
+    // User retitles the session mid-run (cc_session_step 12) — the next
+    // processEvent must surface the new label without waiting for refreshAll.
+    displayNames.set('sess-1', '[#42, 12/13] feat: foo');
+    const next = m.processEvent(makeEvent({ timestamp: Date.now() + 1 }));
+
+    expect(next!.agent.name).toBe('[#42, 12/13] feat: foo');
+  });
+
+  test('refreshAll picks up display-name changes and reports them as changed', () => {
+    const displayNames = new Map<string, string>();
+    const m = new AgentStateManager({
+      displayNameOracle: { getDisplayName: (sid) => displayNames.get(sid) },
+    });
+    m.processEvent(makeEvent());
+    expect(m.getAgent('sess-1')!.name).toBe('bubbly-waddling-cat');
+
+    // No JSONL event arrived, but the registry's next scan tick discovered a
+    // new state.json. refreshAll must rebroadcast on the strength of the name
+    // change alone — otherwise the dashboard freezes on the stale slug.
+    displayNames.set('sess-1', '[#42, DONE] feat: foo');
+    const changed = m.refreshAll();
+
+    expect(changed).toContain('sess-1');
+    expect(m.getAgent('sess-1')!.name).toBe('[#42, DONE] feat: foo');
+  });
+
+  test('display-name oracle does NOT relabel subagents (they have no jobId)', () => {
+    const m = new AgentStateManager({
+      displayNameOracle: {
+        // Bug-bait: an oracle that returns a value for a subagent id would
+        // wipe the filename-derived label, so the manager must skip the lookup.
+        getDisplayName: () => '[#42, 7/13] feat: foo',
+      },
+    });
+
+    const result = m.processEvent(makeEvent({ sessionId: 'agent-helper-1234567890abcdef' }), '', 'claude', 'helper');
+
+    expect(result!.agent.name).toBe('helper');
+  });
+
+  test('falls back to the derived name when the oracle drops the display name', () => {
+    const displayNames = new Map<string, string>([['sess-1', '[#42, 7/13] feat: foo']]);
+    const m = new AgentStateManager({
+      displayNameOracle: { getDisplayName: (sid) => displayNames.get(sid) },
+    });
+
+    // Oracle has a title — agent should pick it up.
+    m.processEvent(makeEvent());
+    expect(m.getAgent('sess-1')!.name).toBe('[#42, 7/13] feat: foo');
+
+    // User removes the state.json (the registry's next scan would drop the entry).
+    // Without the fallback path, agent.name would freeze on the stale title and
+    // refreshAll() wouldn't even mark the session as changed.
+    displayNames.delete('sess-1');
+    const changed = m.refreshAll();
+
+    expect(changed).toContain('sess-1');
+    expect(m.getAgent('sess-1')!.name).toBe('bubbly-waddling-cat');
+  });
+
+  test('falls back to the derived name on the next processEvent after oracle drops the title', () => {
+    const displayNames = new Map<string, string>([['sess-1', '[#42, 7/13] feat: foo']]);
+    const m = new AgentStateManager({
+      displayNameOracle: { getDisplayName: (sid) => displayNames.get(sid) },
+    });
+
+    m.processEvent(makeEvent());
+    expect(m.getAgent('sess-1')!.name).toBe('[#42, 7/13] feat: foo');
+
+    displayNames.delete('sess-1');
+    const next = m.processEvent(makeEvent({ timestamp: Date.now() + 1 }));
+
+    expect(next!.agent.name).toBe('bubbly-waddling-cat');
+  });
+
+  test('setDisplayNameOracle wires the oracle after construction', () => {
+    const m = new AgentStateManager();
+    m.processEvent(makeEvent());
+    expect(m.getAgent('sess-1')!.name).toBe('bubbly-waddling-cat');
+
+    m.setDisplayNameOracle({ getDisplayName: () => '[#1, 5/13] late wiring' });
+    const changed = m.refreshAll();
+
+    expect(changed).toContain('sess-1');
+    expect(m.getAgent('sess-1')!.name).toBe('[#1, 5/13] late wiring');
+  });
 });

--- a/server/src/state/agent-state-manager.ts
+++ b/server/src/state/agent-state-manager.ts
@@ -49,6 +49,16 @@ export interface SessionLivenessOracle {
   isLive(sessionId: string): boolean;
 }
 
+/**
+ * Display-name oracle: returns an optional human-readable label for a session.
+ * Returns undefined when no label is available — callers fall back to the
+ * slug/cwd-basename derivation. The concrete storage (file paths, formats) is
+ * the adapter's concern, not part of this contract.
+ */
+export interface SessionDisplayNameOracle {
+  getDisplayName(sessionId: string): string | undefined;
+}
+
 export interface AgentStateManagerOptions {
   /** Age above which an agent transitions from active → idle (ms). Default 5 min. */
   idleThresholdMs?: number;
@@ -72,6 +82,8 @@ export interface AgentStateManagerOptions {
   subagentBusyCompletedThresholdMs?: number;
   /** Optional oracle for cross-referencing sessions against live Claude pids. */
   livenessOracle?: SessionLivenessOracle;
+  /** Optional oracle for surfacing the user-set session display name as the agent label. */
+  displayNameOracle?: SessionDisplayNameOracle;
 }
 
 function isSubagentSessionId(sessionId: string): boolean {
@@ -89,6 +101,7 @@ export class AgentStateManager {
   private subagentCompletedThresholdMs: number;
   private subagentBusyCompletedThresholdMs: number;
   private livenessOracle: SessionLivenessOracle | undefined;
+  private displayNameOracle: SessionDisplayNameOracle | undefined;
 
   constructor(opts: AgentStateManagerOptions = {}) {
     this.idleThresholdMs = opts.idleThresholdMs ?? 5 * 60_000;
@@ -98,10 +111,15 @@ export class AgentStateManager {
     this.subagentCompletedThresholdMs = opts.subagentCompletedThresholdMs ?? 5 * 60_000;
     this.subagentBusyCompletedThresholdMs = opts.subagentBusyCompletedThresholdMs ?? 15 * 60_000;
     this.livenessOracle = opts.livenessOracle;
+    this.displayNameOracle = opts.displayNameOracle;
   }
 
   setLivenessOracle(oracle: SessionLivenessOracle | undefined): void {
     this.livenessOracle = oracle;
+  }
+
+  setDisplayNameOracle(oracle: SessionDisplayNameOracle | undefined): void {
+    this.displayNameOracle = oracle;
   }
 
   processEvent(
@@ -129,6 +147,7 @@ export class AgentStateManager {
       this.applyTurnAndError(agent, event);
       // Liveness wins over turn-end: a dead pid can't be mid-turn.
       this.applyLivenessOverride(agent);
+      this.applyDisplayName(agent);
       return { agent, isNew: true };
     }
 
@@ -141,6 +160,7 @@ export class AgentStateManager {
       this.applyTurnAndError(existing, event);
       this.applyLivenessOverride(existing);
     }
+    this.applyDisplayName(existing);
     return { agent: existing, isNew: false };
   }
 
@@ -150,12 +170,33 @@ export class AgentStateManager {
     for (const agent of this.agents.values()) {
       const before = agent.status;
       const beforeActivity = agent.currentActivity;
+      const beforeName = agent.name;
       this.applyDerivedStatus(agent);
-      if (agent.status !== before || agent.currentActivity !== beforeActivity) {
+      this.applyDisplayName(agent);
+      if (
+        agent.status !== before ||
+        agent.currentActivity !== beforeActivity ||
+        agent.name !== beforeName
+      ) {
         changed.push(agent.id);
       }
     }
     return changed;
+  }
+
+  /**
+   * Reconcile `agent.name` against the oracle on every tick. Returning to the
+   * derived (slug/cwd) name is just as important as overlaying the oracle's
+   * label — without the fallback path, a removed/corrupt `state.json` would
+   * leave the previous title frozen on the sprite. Subagents are skipped
+   * (they have no jobId of their own and keep the filename descriptor).
+   */
+  private applyDisplayName(agent: AgentState): void {
+    if (isSubagentSessionId(agent.id)) return;
+    const oracleName = this.displayNameOracle?.getDisplayName(agent.id);
+    agent.name = oracleName !== undefined && oracleName.length > 0
+      ? oracleName
+      : agent.derivedName;
   }
 
   /**
@@ -419,14 +460,15 @@ export class AgentStateManager {
     source: AgentSource,
     nameOverride?: string,
   ): AgentState {
-    const name = nameOverride !== undefined && nameOverride.length > 0
+    const derivedName = nameOverride !== undefined && nameOverride.length > 0
       ? nameOverride
       : deriveAgentName(event.slug, event.cwd, event.sessionId);
     const agent: AgentState = {
       id: event.sessionId,
-      name,
+      name: derivedName,
+      derivedName,
       heroClass: this.nextHeroClass(),
-      heroColor: this.pickUnusedColorFor(name),
+      heroColor: this.pickUnusedColorFor(derivedName),
       status: 'active',
       currentActivity: event.activity,
       currentFile: event.file,
@@ -463,12 +505,14 @@ export class AgentStateManager {
     }
 
     // Subagents keep their filename-derived name — the event's slug is the
-    // parent session's slug (copied verbatim) and would be misleading.
+    // parent session's slug (copied verbatim) and would be misleading. Updates
+    // land on `derivedName` so `applyDisplayName()` can swap back when the
+    // oracle drops the user-set title.
     if (!isSubagentId(agent.id)) {
       if (event.slug !== undefined) {
-        agent.name = event.slug;
-      } else if (looksLikeSessionPrefix(agent.name) && event.cwd !== undefined) {
-        agent.name = cwdBasename(event.cwd);
+        agent.derivedName = event.slug;
+      } else if (looksLikeSessionPrefix(agent.derivedName) && event.cwd !== undefined) {
+        agent.derivedName = cwdBasename(event.cwd);
       }
     }
 

--- a/server/src/state/agent-state-manager.ts
+++ b/server/src/state/agent-state-manager.ts
@@ -1,4 +1,4 @@
-import type { AgentSource, AgentState, HeroClass, HeroColor } from '../types';
+import type { AgentSource, AgentState, HeroClass, HeroColor, SubagentContext } from '../types';
 import { HERO_CLASSES, HERO_COLORS } from '../types';
 import type { ParsedEvent } from '../parsers/session-parser';
 
@@ -127,6 +127,7 @@ export class AgentStateManager {
     configDir = '',
     source: AgentSource = 'claude',
     nameOverride?: string,
+    subagentCtx?: SubagentContext,
   ): ProcessResult | null {
     const existing = this.agents.get(event.sessionId);
 
@@ -141,7 +142,7 @@ export class AgentStateManager {
     }
 
     if (existing === undefined) {
-      const agent = this.createAgent(event, configDir, source, nameOverride);
+      const agent = this.createAgent(event, configDir, source, nameOverride, subagentCtx);
       this.agents.set(event.sessionId, agent);
       this.applyDerivedStatus(agent);
       this.applyTurnAndError(agent, event);
@@ -459,6 +460,7 @@ export class AgentStateManager {
     configDir: string,
     source: AgentSource,
     nameOverride?: string,
+    subagentCtx?: SubagentContext,
   ): AgentState {
     const derivedName = nameOverride !== undefined && nameOverride.length > 0
       ? nameOverride
@@ -486,6 +488,8 @@ export class AgentStateManager {
       configDir,
       source,
       model: event.model,
+      isSubagent: subagentCtx?.isSubagent ?? false,
+      parentSessionId: subagentCtx?.parentSessionId,
     };
     return agent;
   }

--- a/server/src/state/agent-state-manager.ts
+++ b/server/src/state/agent-state-manager.ts
@@ -4,6 +4,24 @@ import type { ParsedEvent } from '../parsers/session-parser';
 
 const EDIT_TOOLS = new Set(['Edit', 'Write', 'NotebookEdit']);
 
+// AgentState retention policy: each agent exposes a bounded "recent history"
+// of tool calls and modified files to the UI. The Party Bar, Detail Panel,
+// and village scene only need the most recent activity — older entries are
+// dropped FIFO. Transport-level concerns (payload byte budget, broadcast
+// frame size) live in `WebSocketServer`; this cap is the state manager's own
+// input policy and does not depend on which transport happens to ship it.
+const MAX_TOOL_CALLS_PER_AGENT = 50;
+const MAX_FILES_MODIFIED_PER_AGENT = 50;
+
+function trimAgentHistory(agent: AgentState): void {
+  if (agent.toolCalls.length > MAX_TOOL_CALLS_PER_AGENT) {
+    agent.toolCalls.splice(0, agent.toolCalls.length - MAX_TOOL_CALLS_PER_AGENT);
+  }
+  if (agent.filesModified.length > MAX_FILES_MODIFIED_PER_AGENT) {
+    agent.filesModified.splice(0, agent.filesModified.length - MAX_FILES_MODIFIED_PER_AGENT);
+  }
+}
+
 function cwdBasename(cwd: string): string {
   const parts = cwd.split('/').filter((p) => p.length > 0);
   return parts[parts.length - 1] ?? cwd;
@@ -143,6 +161,7 @@ export class AgentStateManager {
 
     if (existing === undefined) {
       const agent = this.createAgent(event, configDir, source, nameOverride, subagentCtx);
+      trimAgentHistory(agent);
       this.agents.set(event.sessionId, agent);
       this.applyDerivedStatus(agent);
       this.applyTurnAndError(agent, event);
@@ -525,6 +544,7 @@ export class AgentStateManager {
         agent.filesModified.push(f);
       }
     }
+    trimAgentHistory(agent);
   }
 
   private extractModifiedFiles(event: ParsedEvent): string[] {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -38,7 +38,20 @@ export interface ToolCall {
 // --- Core agent state ---
 export interface AgentState {
   id: string;          // sessionId
-  name: string;        // slug from JSONL (e.g. "bubbly-waddling-cat")
+  /**
+   * Label rendered above the hero. Starts as the JSONL slug or cwd basename
+   * (see `derivedName`), and is overlaid with the user-set display title
+   * whenever a `SessionDisplayNameOracle` returns one. Falls back to
+   * `derivedName` the moment the oracle drops the title — otherwise a deleted
+   * `state.json` would freeze a stale label on the sprite forever.
+   */
+  name: string;
+  /**
+   * Slug/cwd-derived label that survives oracle gaps. Recomputed on every
+   * non-subagent JSONL event so a renamed cwd or a slug surfacing late still
+   * lands here without waiting for the oracle to come back.
+   */
+  derivedName: string;
   heroClass: HeroClass;
   heroColor: HeroColor;
   status: 'active' | 'waiting' | 'idle' | 'completed' | 'error';

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -79,6 +79,32 @@ export interface AgentState {
    * sessions and for Claude sessions whose JSONL predates the field.
    */
   model?: string;
+  /**
+   * True when this session was spawned by another session as a sub-agent
+   * (e.g. Claude Code `Agent` / Task tool). Server computes from file-system
+   * layout (subagents/ directory) — client never inspects sessionId patterns
+   * directly. Defaults to false for main sessions and for Codex sessions
+   * (Codex has no sub-agent concept).
+   */
+  isSubagent: boolean;
+  /**
+   * Parent session id when this session is a sub-agent and the parent is
+   * known. Undefined for main sessions and for orphan sub-agents whose
+   * parent jsonl could not be located.
+   */
+  parentSessionId?: string;
+}
+
+// --- Subagent context (anti-corruption boundary) ---
+/**
+ * Carries server-domain knowledge about whether a JSONL file represents a
+ * sub-agent session, plus the parent session id when discoverable. The
+ * file-watcher computes this from disk layout once; downstream layers
+ * (provider, state manager) never inspect file paths or sessionId patterns.
+ */
+export interface SubagentContext {
+  isSubagent: boolean;
+  parentSessionId?: string;
 }
 
 // --- Session metadata from ~/.claude/sessions/<pid>.json

--- a/server/src/watchers/file-watcher.ts
+++ b/server/src/watchers/file-watcher.ts
@@ -2,9 +2,22 @@ import { readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { homedir } from 'node:os';
 
+import type { SubagentContext } from '../types';
+
 export interface WatcherCallbacks {
-  onNewSession: (sessionId: string, projectPath: string, configDir: string) => void;
-  onSessionUpdate: (sessionId: string, projectPath: string, newContent: string, configDir: string) => void;
+  onNewSession: (
+    sessionId: string,
+    projectPath: string,
+    configDir: string,
+    subagentCtx: SubagentContext,
+  ) => void;
+  onSessionUpdate: (
+    sessionId: string,
+    projectPath: string,
+    newContent: string,
+    configDir: string,
+    subagentCtx: SubagentContext,
+  ) => void;
 }
 
 export interface WatcherOptions extends WatcherCallbacks {
@@ -115,12 +128,21 @@ export class FileWatcher {
 
       for (const file of files) {
         if (file.endsWith('.jsonl')) {
-          await this.processJsonlFile(join(projectPath, file), file.replace('.jsonl', ''), claudeDir);
+          await this.processJsonlFile(
+            join(projectPath, file),
+            file.replace('.jsonl', ''),
+            claudeDir,
+            { isSubagent: false },
+          );
           continue;
         }
 
-        // Per-session subdirectories may contain subagent JSONLs at <sessionId>/subagents/agent-*.jsonl
-        const subagentsDir = join(projectPath, file, 'subagents');
+        // Per-session subdirectories may contain subagent JSONLs at
+        // <parentSessionId>/subagents/agent-*.jsonl. The directory name *is*
+        // the parent session id — this is the anti-corruption boundary where
+        // disk layout becomes domain metadata (`SubagentContext`).
+        const parentSessionId = file;
+        const subagentsDir = join(projectPath, parentSessionId, 'subagents');
         const subStat = await stat(subagentsDir).catch(() => null);
         if (subStat === null || !subStat.isDirectory()) continue;
 
@@ -129,13 +151,23 @@ export class FileWatcher {
 
         for (const subFile of subFiles) {
           if (!subFile.endsWith('.jsonl')) continue;
-          await this.processJsonlFile(join(subagentsDir, subFile), subFile.replace('.jsonl', ''), claudeDir);
+          await this.processJsonlFile(
+            join(subagentsDir, subFile),
+            subFile.replace('.jsonl', ''),
+            claudeDir,
+            { isSubagent: true, parentSessionId },
+          );
         }
       }
     }
   }
 
-  private async processJsonlFile(filePath: string, sessionId: string, claudeDir: string): Promise<void> {
+  private async processJsonlFile(
+    filePath: string,
+    sessionId: string,
+    claudeDir: string,
+    subagentCtx: SubagentContext,
+  ): Promise<void> {
     const fileStat = await stat(filePath).catch(() => null);
     if (fileStat === null) return;
 
@@ -153,14 +185,14 @@ export class FileWatcher {
       }
       // New session file
       this.fileSizes.set(filePath, currentSize);
-      this.callbacks.onNewSession(sessionId, filePath, claudeDir);
+      this.callbacks.onNewSession(sessionId, filePath, claudeDir, subagentCtx);
     } else if (currentSize > previousSize) {
       // File grew — read only the new bytes
       const fd = Bun.file(filePath);
       const newBytes = fd.slice(previousSize, currentSize);
       const newContent = await newBytes.text();
       this.fileSizes.set(filePath, currentSize);
-      this.callbacks.onSessionUpdate(sessionId, filePath, newContent, claudeDir);
+      this.callbacks.onSessionUpdate(sessionId, filePath, newContent, claudeDir, subagentCtx);
     }
   }
 }

--- a/server/src/ws/websocket-server.ts
+++ b/server/src/ws/websocket-server.ts
@@ -3,6 +3,11 @@ import type { WsEvent, AgentState } from '../types';
 
 export type WsClient = ServerWebSocket<{ id: string }>;
 
+// Warn when a single broadcast frame crosses this size — historically the
+// snapshot grew large enough (multi-MB) to make the browser drop the WS on
+// connect (issue #7). Keeps an eye on regressions without flooding the log.
+const LARGE_MESSAGE_WARN_BYTES = 500 * 1024;
+
 export class WebSocketServer {
   private clients = new Set<WsClient>();
 
@@ -11,14 +16,24 @@ export class WebSocketServer {
     console.log(`[WS] client connected (total: ${this.clients.size})`);
   }
 
-  handleClose(ws: WsClient): void {
+  handleClose(ws: WsClient, code?: number, reason?: string): void {
     this.clients.delete(ws);
-    console.log(`[WS] client disconnected (total: ${this.clients.size})`);
+    // code/reason help diagnose abnormal disconnects — e.g. 1009 (message too
+    // big), 1006 (abnormal closure). Empty reason and code 1000 are normal.
+    const codeStr = code !== undefined ? String(code) : '?';
+    const reasonStr = reason !== undefined && reason.length > 0 ? ` reason="${reason}"` : '';
+    console.log(`[WS] client disconnected (total: ${this.clients.size}) code=${codeStr}${reasonStr}`);
   }
 
   sendSnapshot(ws: WsClient, agents: AgentState[], configDirs: readonly string[]): void {
     const event: WsEvent = { type: 'snapshot', agents, configDirs: [...configDirs] };
-    ws.send(JSON.stringify(event));
+    const data = JSON.stringify(event);
+    const bytes = Buffer.byteLength(data, 'utf8');
+    console.log(`[WS] snapshot bytes=${bytes} agents=${agents.length}`);
+    if (bytes > LARGE_MESSAGE_WARN_BYTES) {
+      console.warn(`[WS] large snapshot frame: ${bytes} bytes (warn threshold: ${LARGE_MESSAGE_WARN_BYTES})`);
+    }
+    ws.send(data);
   }
 
   broadcastAgentUpdate(agent: AgentState): void {
@@ -43,6 +58,10 @@ export class WebSocketServer {
 
   private broadcast(event: WsEvent): void {
     const data = JSON.stringify(event);
+    const bytes = Buffer.byteLength(data, 'utf8');
+    if (bytes > LARGE_MESSAGE_WARN_BYTES) {
+      console.warn(`[WS] large ${event.type} frame: ${bytes} bytes (warn threshold: ${LARGE_MESSAGE_WARN_BYTES})`);
+    }
     for (const client of this.clients) {
       client.send(data);
     }

--- a/server/src/ws/websocket-server.ts
+++ b/server/src/ws/websocket-server.ts
@@ -13,27 +13,41 @@ export class WebSocketServer {
 
   handleOpen(ws: WsClient): void {
     this.clients.add(ws);
-    console.log(`[WS] client connected (total: ${this.clients.size})`);
+    console.log(`[WS] client connected clientId=${ws.data.id} (total: ${this.clients.size})`);
   }
 
   handleClose(ws: WsClient, code?: number, reason?: string): void {
     this.clients.delete(ws);
     // code/reason help diagnose abnormal disconnects — e.g. 1009 (message too
     // big), 1006 (abnormal closure). Empty reason and code 1000 are normal.
+    // clientId pairs the close with the matching open / snapshot send under
+    // StrictMode double-mount and multi-tab races (issue #11).
     const codeStr = code !== undefined ? String(code) : '?';
     const reasonStr = reason !== undefined && reason.length > 0 ? ` reason="${reason}"` : '';
-    console.log(`[WS] client disconnected (total: ${this.clients.size}) code=${codeStr}${reasonStr}`);
+    console.log(
+      `[WS] client disconnected clientId=${ws.data.id} (total: ${this.clients.size}) code=${codeStr}${reasonStr}`,
+    );
   }
 
   sendSnapshot(ws: WsClient, agents: AgentState[], configDirs: readonly string[]): void {
     const event: WsEvent = { type: 'snapshot', agents, configDirs: [...configDirs] };
     const data = JSON.stringify(event);
     const bytes = Buffer.byteLength(data, 'utf8');
-    console.log(`[WS] snapshot bytes=${bytes} agents=${agents.length}`);
+    // readyState before and after send pins down whether Bun saw the socket as
+    // OPEN at send time, and whether send() itself flipped it. sendResult is
+    // Bun-specific: -1 = backpressure, 0 = dropped, 1+ = bytes sent. clientId
+    // pairs this with the matching open/close in the log under reconnect
+    // storms (issue #11).
+    const readyBefore = ws.readyState;
+    const sendResult = ws.send(data);
+    const readyAfter = ws.readyState;
+    console.log(
+      `[WS] snapshot clientId=${ws.data.id} bytes=${bytes} agents=${agents.length} ` +
+        `readyBefore=${readyBefore} sendResult=${sendResult} readyAfter=${readyAfter}`,
+    );
     if (bytes > LARGE_MESSAGE_WARN_BYTES) {
       console.warn(`[WS] large snapshot frame: ${bytes} bytes (warn threshold: ${LARGE_MESSAGE_WARN_BYTES})`);
     }
-    ws.send(data);
   }
 
   broadcastAgentUpdate(agent: AgentState): void {


### PR DESCRIPTION
## 변경 요약

마을 화면에서 sub-agent를 한눈에 구분할 수 있도록 세 가지 시각 구분 요소를 추가합니다.

### 추가된 시각 요소

**1. Pulsing glow ring (HeroSprite)**
- sub-agent sprite 주변에 보라색(#9b72cf) 원형 outline을 렌더링
- 1.2초 주기로 alpha가 0.35 ↔ 0.8 사이를 부드럽게 pulse해 복잡한 장면에서도 눈에 띔
- 스케일 변화에 자동 적응 (displayWidth 기반으로 반지름 계산)

**2. ⚙ gear icon badge (HeroSprite)**
- sprite 우상단에 작은 ⚙ 기호를 보라빛(#c8a8ff) 텍스트로 표시
- 반투명 다크 배경으로 어떤 지형 위에서도 가독성 확보
- 커스텀 텍스처 없이 유니코드 문자 재사용 → 에셋 추가 불필요

**3. 점선 connector line (VillageScene)**
- 매 프레임 parent hero → attached sub-agent 사이를 CONNECTOR_DASH_LENGTH(6px) / CONNECTOR_GAP_LENGTH(4px) 점선으로 연결
- 단일 reusable Graphics 레이어 () 를 clear 후 재사용 → GC 압력 없음
- sub-agent가 detach되면 다음 프레임에 자동 소거

### 쇼츠 PiP 가시성

세 요소 모두 Phaser 캔버스 레이어에 렌더링되므로 PiP 화면에서도 동일하게 표시됩니다.

### 신규 파일

**`client/src/game/scenes/subagent-connector.ts`**  
연결선 geometry 계산 pure 모듈 (`buildConnectorSegments` + visual 상수). Phaser 의존 없음 → 단위 테스트 가능.

**`client/src/game/scenes/subagent-connector.test.ts`**  
11개 단위 테스트 — 선분 geometry, 상수 범위 유효성, 결정론적 출력 검증.

## 테스트 결과

```
bun test: 305 pass, 0 fail (25 files)
TypeScript: 0 errors
```

## 주의 (이슈 #23 동시 진행)

이슈 #23 (building 배치 재배치)과 동시 진행 중이나, `building-layout.ts`는 건드리지 않았습니다.  
main sync 후 conflict 없음 확인됨.

Closes #24

---
<details>
<summary>🤖 Claude Code session</summary>

- Session ID: `8669ee13-9c50-4a09-be42-4947fafa7989`
- Resume: `claudeauto --resume 8669ee13-9c50-4a09-be42-4947fafa7989`
- Transcript: `/Users/ms/.claude/projects/-Users-ms-Desktop-projects-worktrees-Agent-Quest-issues-20/8669ee13-9c50-4a09-be42-4947fafa7989.jsonl`
</details>